### PR TITLE
Hardcoded Secrets entfernen

### DIFF
--- a/Einkaufsliste/Program.cs
+++ b/Einkaufsliste/Program.cs
@@ -12,7 +12,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHttpClient();
 
 var connStr = builder.Configuration.GetConnectionString("Default")
-    ?? "Server=localhost;Database=Einkaufsliste;User Id=pmi;Password=wsvdqtnfhsnv;TrustServerCertificate=true";
+    ?? throw new InvalidOperationException("ConnectionStrings:Default ist nicht konfiguriert. Bitte in appsettings.json, Umgebungsvariablen oder User Secrets setzen.");
 
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie(o =>
@@ -121,14 +121,15 @@ bool VerifyPassword(string password, string stored)
         ALTER TABLE Haushalt ADD ErstelltVon INT NULL", conn);
     erstelltVonCol.ExecuteNonQuery();
 
+    var adminPassword = builder.Configuration["AdminPassword"] ?? "";
     using var checkCmd = new SqlCommand("SELECT COUNT(*) FROM Benutzer WHERE Benutzername='Admin'", conn);
-    if ((int)checkCmd.ExecuteScalar()! == 0)
+    if ((int)checkCmd.ExecuteScalar()! == 0 && adminPassword.Length >= 4)
     {
         using var cmd = new SqlCommand(
             "INSERT INTO Benutzer (Benutzername, PasswordHash, EmailBestaetigt, IsAdmin) VALUES ('Admin', @hash, 1, 1)", conn);
-        cmd.Parameters.AddWithValue("@hash", HashPassword("Admin123!"));
+        cmd.Parameters.AddWithValue("@hash", HashPassword(adminPassword));
         cmd.ExecuteNonQuery();
-        app.Logger.LogInformation("Admin-Benutzer erstellt (Passwort: Admin123!)");
+        app.Logger.LogInformation("Admin-Benutzer erstellt");
     }
 }
 

--- a/Einkaufsliste/appsettings.json
+++ b/Einkaufsliste/appsettings.json
@@ -7,11 +7,11 @@
   },
   "AllowedHosts": "*",
   "Smtp": {
-    "Host": "server75.hostfactory.ch",
+    "Host": "",
     "Port": 587,
-    "User": "noreplay@sithamparam.ch",
-    "Password": "TJgsGWx&K9kWN^KeeDRB",
-    "From": "noreplay@sithamparam.ch",
+    "User": "",
+    "Password": "",
+    "From": "",
     "FromName": "Einkaufsliste"
   }
 }


### PR DESCRIPTION
## Summary
- SMTP-Credentials aus `appsettings.json` entfernt (waren öffentlich sichtbar)
- Hardcoded DB-Connection-String mit Passwort aus `Program.cs` entfernt
- Admin-Passwort wird aus Konfiguration (`AdminPassword`) gelesen statt hardcoded
- Admin-Passwort wird nicht mehr in Logs ausgegeben

## Test plan
- [ ] App startet mit korrekt konfigurierter `appsettings.Development.json`
- [ ] App wirft Exception wenn `ConnectionStrings:Default` fehlt
- [ ] Admin-User wird nur erstellt wenn `AdminPassword` konfiguriert ist
- [ ] SMTP funktioniert mit Credentials in `appsettings.Development.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)