### PR TITLE
GitHub Actions CI/CD Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [release]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish
+        run: dotnet publish Einkaufsliste/Einkaufsliste.csproj -c Release -o ./publish
+
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_HOST }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          local-dir: ./publish/
+          server-dir: /subdomains/einkaufsliste/httpdocs/


### PR DESCRIPTION
## Summary
- GitHub Actions Workflow für automatisches Deployment bei Push auf `release`
- Build mit `dotnet publish` (Release-Konfiguration)
- Upload via FTP auf Hostfactory-Server (`einkaufsliste.sithamparam.ch`)
- FTP-Credentials als GitHub Secrets gespeichert (FTP_HOST, FTP_USERNAME, FTP_PASSWORD)

## Deployment-Flow
1. Feature-Branch → PR → `develop` (Entwicklung)
2. `develop` → PR → `release` (Release)
3. Push auf `release` → GitHub Actions → FTP-Deploy auf Server

## Test plan
- [ ] Workflow wird bei Push auf `release` ausgelöst
- [ ] `dotnet publish` baut erfolgreich
- [ ] FTP-Upload in `/subdomains/einkaufsliste/httpdocs/`
- [ ] App ist unter `einkaufsliste.sithamparam.ch` erreichbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)