### PR TITLE
Fix: app_offline.htm nach Deploy entfernen

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,3 +71,10 @@ jobs:
           password: ${{ secrets.FTP_PASSWORD }}
           local-dir: ./publish/
           server-dir: /subdomains/einkaufsliste/httpdocs/
+
+      - name: Remove app_offline.htm to restart IIS
+        run: |
+          curl -s --ftp-create-dirs \
+            -u "${{ secrets.FTP_USERNAME }}:${{ secrets.FTP_PASSWORD }}" \
+            "ftp://${{ secrets.FTP_HOST }}/subdomains/einkaufsliste/httpdocs/" \
+            -Q "DELE /subdomains/einkaufsliste/httpdocs/app_offline.htm"


### PR DESCRIPTION
Löscht app_offline.htm nach dem FTP-Deploy, damit IIS die App wieder startet.