### PR TITLE
Fix: win-x86 für 32-bit IIS

### DIFF
--- a/Einkaufsliste/Einkaufsliste.csproj
+++ b/Einkaufsliste/Einkaufsliste.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 


### PR DESCRIPTION
IIS läuft als 32-bit, RuntimeIdentifier von win-x64 auf win-x86 geändert.