### PR TITLE
Framework-dependent Deploy

### DIFF
--- a/Einkaufsliste/Einkaufsliste.csproj
+++ b/Einkaufsliste/Einkaufsliste.csproj
@@ -4,8 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Einkaufsliste/web.config
+++ b/Einkaufsliste/web.config
@@ -5,7 +5,7 @@
       <handlers>
         <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
       </handlers>
-      <aspNetCore processPath=".\Einkaufsliste.exe" arguments="" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="outofprocess">
+      <aspNetCore processPath="dotnet" arguments=".\Einkaufsliste.dll" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="inprocess">
         <environmentVariables>
           <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Production" />
         </environmentVariables>


### PR DESCRIPTION
Nutzt die auf dem Server installierte .NET 8 Runtime statt self-contained.