### PR TITLE
Switch to iisnode for Node.js IIS hosting

### DIFF
--- a/web.config
+++ b/web.config
@@ -2,13 +2,19 @@
 <configuration>
   <system.webServer>
     <handlers>
-      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
+      <add name="iisnode" path="server.js" verb="*" modules="iisnode" />
     </handlers>
-    <httpPlatform processPath="node.exe" arguments="server.js" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" startupTimeLimit="60">
-      <environmentVariables>
-        <environmentVariable name="PORT" value="%HTTP_PLATFORM_PORT%" />
-        <environmentVariable name="NODE_ENV" value="production" />
-      </environmentVariables>
-    </httpPlatform>
+    <rewrite>
+      <rules>
+        <rule name="nodejs" stopProcessing="true">
+          <match url=".*" />
+          <action type="Rewrite" url="server.js" />
+        </rule>
+      </rules>
+    </rewrite>
+    <iisnode nodeProcessCommandLine="node.exe"
+             loggingEnabled="true"
+             logDirectory="logs"
+             devErrorsEnabled="true" />
   </system.webServer>
 </configuration>


### PR DESCRIPTION
## Summary
- Switch web.config from HttpPlatformHandler to iisnode module
- HttpPlatformHandler returned generic 500 error (likely not installed on Plesk server)
- iisnode is more commonly available on shared Windows hosting

## Test plan
- [ ] Deploy to production and verify the app loads at einkaufsliste.sithamparam.ch

🤖 Generated with [Claude Code](https://claude.com/claude-code)