### PR TITLE
Deploy iisnode web.config to production

### DIFF
--- a/web.config
+++ b/web.config
@@ -2,13 +2,19 @@
 <configuration>
   <system.webServer>
     <handlers>
-      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
+      <add name="iisnode" path="server.js" verb="*" modules="iisnode" />
     </handlers>
-    <httpPlatform processPath="node.exe" arguments="server.js" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" startupTimeLimit="60">
-      <environmentVariables>
-        <environmentVariable name="PORT" value="%HTTP_PLATFORM_PORT%" />
-        <environmentVariable name="NODE_ENV" value="production" />
-      </environmentVariables>
-    </httpPlatform>
+    <rewrite>
+      <rules>
+        <rule name="nodejs" stopProcessing="true">
+          <match url=".*" />
+          <action type="Rewrite" url="server.js" />
+        </rule>
+      </rules>
+    </rewrite>
+    <iisnode nodeProcessCommandLine="node.exe"
+             loggingEnabled="true"
+             logDirectory="logs"
+             devErrorsEnabled="true" />
   </system.webServer>
 </configuration>


### PR DESCRIPTION
## Summary
- Merge develop into release to deploy iisnode configuration
- Fixes generic IIS 500 error by switching from HttpPlatformHandler to iisnode

🤖 Generated with [Claude Code](https://claude.com/claude-code)