### PR TITLE
Disable iisnode logging to fix permission error

### DIFF
--- a/web.config
+++ b/web.config
@@ -13,8 +13,7 @@
       </rules>
     </rewrite>
     <iisnode nodeProcessCommandLine="node.exe"
-             loggingEnabled="true"
-             logDirectory="logs"
+             loggingEnabled="false"
              devErrorsEnabled="true" />
   </system.webServer>
 </configuration>


### PR DESCRIPTION
## Summary
- iisnode is working but fails with HRESULT 0x2 (subStatus 1002) because it can't create log files
- Disable logging to allow the app to start

🤖 Generated with [Claude Code](https://claude.com/claude-code)