### PR TITLE
Start server before DB init for iisnode compatibility

### DIFF
--- a/server.js
+++ b/server.js
@@ -1792,16 +1792,19 @@ async function startup() {
       }
     }
 
-    const port = process.env.PORT || 3000;
-    app.listen(port, () => {
-      console.log(`Server listening on port ${port}`);
-    });
+    console.log('Database initialized successfully');
   } catch (err) {
-    const logPath = path.join(__dirname, 'startup-error.txt');
-    fs.writeFileSync(logPath, `${new Date().toISOString()}\n${err.stack || err}`);
     console.error('Startup error:', err);
-    throw err;
+    try {
+      const logPath = path.join(__dirname, 'startup-error.txt');
+      fs.writeFileSync(logPath, `${new Date().toISOString()}\n${err.stack || err}`);
+    } catch { /* ignore write errors */ }
   }
 }
 
-startup();
+// Start server immediately, then initialize DB in background
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+  startup();
+});


### PR DESCRIPTION
## Summary
- Start HTTP server immediately so iisnode sees a running process
- Run DB initialization in background after server starts
- Prevents crash-loop when DB is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)