### PR TITLE
Passwort-Richtlinien mit Live-Validierung

### DIFF
--- a/public/register.html
+++ b/public/register.html
@@ -31,8 +31,19 @@
                 </div>
                 <div>
                     <label for="regPass">Passwort</label>
-                    <input type="password" id="regPass" required autocomplete="new-password" placeholder="Mindestens 8 Zeichen">
+                    <input type="password" id="regPass" required autocomplete="new-password" placeholder="Passwort eingeben" oninput="checkPasswordPolicy()">
                 </div>
+                <div id="pwPolicy" style="font-size:0.78rem;line-height:1.6;margin:-0.25rem 0">
+                    <div id="pol-len"><i class="bi bi-x-circle"></i> Mindestens 8 Zeichen</div>
+                    <div id="pol-upper"><i class="bi bi-x-circle"></i> Mindestens 1 Grossbuchstabe</div>
+                    <div id="pol-lower"><i class="bi bi-x-circle"></i> Mindestens 1 Kleinbuchstabe</div>
+                    <div id="pol-special"><i class="bi bi-x-circle"></i> Mindestens 1 Sonderzeichen</div>
+                </div>
+                <div>
+                    <label for="regPassConfirm">Passwort bestätigen</label>
+                    <input type="password" id="regPassConfirm" required autocomplete="new-password" placeholder="Passwort wiederholen" oninput="checkPasswordPolicy()">
+                </div>
+                <div id="pol-match" style="font-size:0.78rem;display:none"><i class="bi bi-x-circle"></i> Passwörter stimmen überein</div>
                 <div id="regError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500"></div>
                 <div id="regSuccess" style="display:none;color:var(--green-600);font-size:0.8rem;font-weight:500"></div>
                 <button type="submit" class="btn btn-primary" style="width:100%;padding:0.7rem;font-size:0.95rem" id="regBtn">
@@ -47,19 +58,51 @@
 </div>
 
 <script>
+function checkPasswordPolicy() {
+    const pass = document.getElementById('regPass').value;
+    const confirm = document.getElementById('regPassConfirm').value;
+    const rules = [
+        { id: 'pol-len', ok: pass.length >= 8 },
+        { id: 'pol-upper', ok: /[A-Z]/.test(pass) },
+        { id: 'pol-lower', ok: /[a-z]/.test(pass) },
+        { id: 'pol-special', ok: /[^A-Za-z0-9]/.test(pass) },
+    ];
+    rules.forEach(r => {
+        const el = document.getElementById(r.id);
+        el.style.color = r.ok ? 'var(--green-600)' : 'var(--red-500)';
+        el.querySelector('i').className = r.ok ? 'bi bi-check-circle-fill' : 'bi bi-x-circle';
+    });
+    const matchEl = document.getElementById('pol-match');
+    if (confirm.length > 0) {
+        matchEl.style.display = '';
+        const ok = pass === confirm && pass.length > 0;
+        matchEl.style.color = ok ? 'var(--green-600)' : 'var(--red-500)';
+        matchEl.querySelector('i').className = ok ? 'bi bi-check-circle-fill' : 'bi bi-x-circle';
+    } else {
+        matchEl.style.display = 'none';
+    }
+    return rules.every(r => r.ok) && pass === confirm;
+}
+
 async function submitRegister(e) {
     e.preventDefault();
     const user = document.getElementById('regUser').value.trim();
     const email = document.getElementById('regEmail').value.trim();
     const pass = document.getElementById('regPass').value;
+    const confirm = document.getElementById('regPassConfirm').value;
     const errEl = document.getElementById('regError');
     const successEl = document.getElementById('regSuccess');
     const btn = document.getElementById('regBtn');
     errEl.style.display = 'none';
     successEl.style.display = 'none';
 
-    if (!user || !email || !pass) {
+    if (!user || !email || !pass || !confirm) {
         errEl.textContent = 'Bitte alle Felder ausfüllen.';
+        errEl.style.display = '';
+        return;
+    }
+    if (!checkPasswordPolicy()) {
+        errEl.textContent = 'Bitte alle Passwort-Anforderungen erfüllen.';
         errEl.style.display = '';
         return;
     }

--- a/public/reset.html
+++ b/public/reset.html
@@ -50,12 +50,19 @@
                 <div style="display:flex;flex-direction:column;gap:0.75rem">
                     <div>
                         <label for="newPass">Neues Passwort</label>
-                        <input type="password" id="newPass" required autocomplete="new-password" placeholder="Mindestens 4 Zeichen">
+                        <input type="password" id="newPass" required autocomplete="new-password" placeholder="Passwort eingeben" oninput="checkPasswordPolicy()">
+                    </div>
+                    <div id="pwPolicy" style="font-size:0.78rem;line-height:1.6;margin:-0.25rem 0">
+                        <div id="pol-len"><i class="bi bi-x-circle"></i> Mindestens 8 Zeichen</div>
+                        <div id="pol-upper"><i class="bi bi-x-circle"></i> Mindestens 1 Grossbuchstabe</div>
+                        <div id="pol-lower"><i class="bi bi-x-circle"></i> Mindestens 1 Kleinbuchstabe</div>
+                        <div id="pol-special"><i class="bi bi-x-circle"></i> Mindestens 1 Sonderzeichen</div>
                     </div>
                     <div>
                         <label for="newPassConfirm">Passwort bestätigen</label>
-                        <input type="password" id="newPassConfirm" required autocomplete="new-password" placeholder="Passwort wiederholen">
+                        <input type="password" id="newPassConfirm" required autocomplete="new-password" placeholder="Passwort wiederholen" oninput="checkPasswordPolicy()">
                     </div>
+                    <div id="pol-match" style="font-size:0.78rem;display:none"><i class="bi bi-x-circle"></i> Passwörter stimmen überein</div>
                     <div id="resetError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500"></div>
                     <div id="resetSuccess" style="display:none;color:var(--green-600);font-size:0.8rem;font-weight:500"></div>
                     <button type="submit" class="btn btn-primary" style="width:100%;padding:0.7rem;font-size:0.95rem" id="resetBtn">
@@ -106,6 +113,32 @@ async function requestReset(e) {
     }
 }
 
+function checkPasswordPolicy() {
+    const pass = document.getElementById('newPass').value;
+    const conf = document.getElementById('newPassConfirm').value;
+    const rules = [
+        { id: 'pol-len', ok: pass.length >= 8 },
+        { id: 'pol-upper', ok: /[A-Z]/.test(pass) },
+        { id: 'pol-lower', ok: /[a-z]/.test(pass) },
+        { id: 'pol-special', ok: /[^A-Za-z0-9]/.test(pass) },
+    ];
+    rules.forEach(r => {
+        const el = document.getElementById(r.id);
+        el.style.color = r.ok ? 'var(--green-600)' : 'var(--red-500)';
+        el.querySelector('i').className = r.ok ? 'bi bi-check-circle-fill' : 'bi bi-x-circle';
+    });
+    const matchEl = document.getElementById('pol-match');
+    if (conf.length > 0) {
+        matchEl.style.display = '';
+        const ok = pass === conf && pass.length > 0;
+        matchEl.style.color = ok ? 'var(--green-600)' : 'var(--red-500)';
+        matchEl.querySelector('i').className = ok ? 'bi bi-check-circle-fill' : 'bi bi-x-circle';
+    } else {
+        matchEl.style.display = 'none';
+    }
+    return rules.every(r => r.ok) && pass === conf;
+}
+
 async function submitReset(e) {
     e.preventDefault();
     const pass = document.getElementById('newPass').value;
@@ -116,13 +149,8 @@ async function submitReset(e) {
     errEl.style.display = 'none';
     successEl.style.display = 'none';
 
-    if (pass !== confirm) {
-        errEl.textContent = 'Passwörter stimmen nicht überein.';
-        errEl.style.display = '';
-        return;
-    }
-    if (pass.length < 4) {
-        errEl.textContent = 'Passwort muss mindestens 4 Zeichen haben.';
+    if (!checkPasswordPolicy()) {
+        errEl.textContent = 'Bitte alle Passwort-Anforderungen erfüllen.';
         errEl.style.display = '';
         return;
     }

--- a/server.js
+++ b/server.js
@@ -487,6 +487,9 @@ app.post('/api/auth/register', async (req, res) => {
 
     if (username.length < 2) return res.status(400).json({ error: 'Benutzername muss mindestens 2 Zeichen haben.' });
     if (password.length < 8) return res.status(400).json({ error: 'Passwort muss mindestens 8 Zeichen haben.' });
+    if (!/[A-Z]/.test(password)) return res.status(400).json({ error: 'Passwort muss mindestens einen Grossbuchstaben enthalten.' });
+    if (!/[a-z]/.test(password)) return res.status(400).json({ error: 'Passwort muss mindestens einen Kleinbuchstaben enthalten.' });
+    if (!/[^A-Za-z0-9]/.test(password)) return res.status(400).json({ error: 'Passwort muss mindestens ein Sonderzeichen enthalten.' });
     if (emailAddr.length < 5 || !emailAddr.includes('@')) return res.status(400).json({ error: 'Bitte eine gültige E-Mail-Adresse eingeben.' });
 
     const db = await getPool();
@@ -682,6 +685,9 @@ app.post('/api/auth/reset', async (req, res) => {
     const password = req.body.passwort || '';
 
     if (password.length < 8) return res.status(400).json({ error: 'Passwort muss mindestens 8 Zeichen haben.' });
+    if (!/[A-Z]/.test(password)) return res.status(400).json({ error: 'Passwort muss mindestens einen Grossbuchstaben enthalten.' });
+    if (!/[a-z]/.test(password)) return res.status(400).json({ error: 'Passwort muss mindestens einen Kleinbuchstaben enthalten.' });
+    if (!/[^A-Za-z0-9]/.test(password)) return res.status(400).json({ error: 'Passwort muss mindestens ein Sonderzeichen enthalten.' });
 
     const db = await getPool();
     const find = await db.request()
@@ -1208,7 +1214,7 @@ app.put('/api/admin/benutzer/:id', requireAuth, async (req, res) => {
         .input('id', sql.Int, id)
         .query('UPDATE Benutzer SET IsAdmin=@val WHERE Id=@id');
     }
-    if (req.body.passwort && req.body.passwort.length >= 8) {
+    if (req.body.passwort && req.body.passwort.length >= 8 && /[A-Z]/.test(req.body.passwort) && /[a-z]/.test(req.body.passwort) && /[^A-Za-z0-9]/.test(req.body.passwort)) {
       await db.request()
         .input('hash', sql.NVarChar, hashPassword(req.body.passwort))
         .input('id', sql.Int, id)


### PR DESCRIPTION
## Summary
- Passwort-Richtlinien verschärft: min. 8 Zeichen, Grossbuchstabe, Kleinbuchstabe, Sonderzeichen
- Live-Checkliste beim Tippen (rot/grün Icons) auf Registrierungs- und Reset-Seite
- Passwort-Bestätigungsfeld bei der Registrierung hinzugefügt
- Backend-Validierung für Register, Reset und Admin-Endpunkte

## Test plan
- [ ] Registrierung: Checkliste prüfen (jede Regel einzeln testen)
- [ ] Registrierung: Passwort-Bestätigung muss übereinstimmen
- [ ] Passwort-Reset: gleiche Richtlinien und Live-Feedback
- [ ] Backend: ungültige Passwörter werden abgelehnt

🤖 Generated with [Claude Code](https://claude.com/claude-code)