### PR TITLE
Passwort ändern im Benutzerprofil

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -261,9 +261,35 @@
                 <label for="profilEmail">E-Mail</label>
                 <input type="email" id="profilEmail" placeholder="name@beispiel.ch">
             </div>
-            <div style="display:flex;gap:0.5rem;justify-content:flex-end">
+            <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-bottom:1.25rem">
                 <button class="btn btn-secondary" onclick="closeProfil()">Abbrechen</button>
                 <button class="btn btn-primary" onclick="saveProfil()"><i class="bi bi-check-lg"></i> Speichern</button>
+            </div>
+            <hr style="border:none;border-top:1px solid var(--gray-200);margin-bottom:1rem">
+            <h3 style="font-size:0.95rem;margin-bottom:0.75rem"><i class="bi bi-key"></i> Passwort ändern</h3>
+            <div style="margin-bottom:0.75rem">
+                <label for="profilOldPass">Aktuelles Passwort</label>
+                <input type="password" id="profilOldPass" autocomplete="current-password" placeholder="Aktuelles Passwort">
+            </div>
+            <div style="margin-bottom:0.5rem">
+                <label for="profilNewPass">Neues Passwort</label>
+                <input type="password" id="profilNewPass" autocomplete="new-password" placeholder="Neues Passwort" oninput="checkProfilPwPolicy()">
+            </div>
+            <div id="profilPwPolicy" style="font-size:0.78rem;line-height:1.6;margin-bottom:0.5rem">
+                <div id="ppol-len"><i class="bi bi-x-circle"></i> Mindestens 8 Zeichen</div>
+                <div id="ppol-upper"><i class="bi bi-x-circle"></i> Mindestens 1 Grossbuchstabe</div>
+                <div id="ppol-lower"><i class="bi bi-x-circle"></i> Mindestens 1 Kleinbuchstabe</div>
+                <div id="ppol-special"><i class="bi bi-x-circle"></i> Mindestens 1 Sonderzeichen</div>
+            </div>
+            <div style="margin-bottom:0.75rem">
+                <label for="profilNewPassConfirm">Neues Passwort bestätigen</label>
+                <input type="password" id="profilNewPassConfirm" autocomplete="new-password" placeholder="Passwort wiederholen" oninput="checkProfilPwPolicy()">
+            </div>
+            <div id="ppol-match" style="font-size:0.78rem;display:none;margin-bottom:0.5rem"><i class="bi bi-x-circle"></i> Passwörter stimmen überein</div>
+            <div id="profilPwError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
+            <div id="profilPwSuccess" style="display:none;color:var(--green-600);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
+            <div style="display:flex;justify-content:flex-end">
+                <button class="btn btn-primary" onclick="changePassword()"><i class="bi bi-key"></i> Passwort ändern</button>
             </div>
         </div>
     </div>

--- a/public/shared.js
+++ b/public/shared.js
@@ -99,6 +99,83 @@ function openProfil() {
 
 function closeProfil() {
     document.getElementById('profilOverlay').classList.remove('active');
+    // Reset password fields
+    const ids = ['profilOldPass', 'profilNewPass', 'profilNewPassConfirm'];
+    ids.forEach(id => { const el = document.getElementById(id); if (el) el.value = ''; });
+    const errEl = document.getElementById('profilPwError');
+    const successEl = document.getElementById('profilPwSuccess');
+    if (errEl) errEl.style.display = 'none';
+    if (successEl) successEl.style.display = 'none';
+    resetProfilPwPolicy();
+}
+
+function resetProfilPwPolicy() {
+    ['ppol-len','ppol-upper','ppol-lower','ppol-special'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) { el.style.color = ''; el.querySelector('i').className = 'bi bi-x-circle'; }
+    });
+    const matchEl = document.getElementById('ppol-match');
+    if (matchEl) matchEl.style.display = 'none';
+}
+
+function checkProfilPwPolicy() {
+    const pass = document.getElementById('profilNewPass').value;
+    const conf = document.getElementById('profilNewPassConfirm').value;
+    const rules = [
+        { id: 'ppol-len', ok: pass.length >= 8 },
+        { id: 'ppol-upper', ok: /[A-Z]/.test(pass) },
+        { id: 'ppol-lower', ok: /[a-z]/.test(pass) },
+        { id: 'ppol-special', ok: /[^A-Za-z0-9]/.test(pass) },
+    ];
+    rules.forEach(r => {
+        const el = document.getElementById(r.id);
+        if (el) {
+            el.style.color = r.ok ? 'var(--green-600)' : 'var(--red-500)';
+            el.querySelector('i').className = r.ok ? 'bi bi-check-circle-fill' : 'bi bi-x-circle';
+        }
+    });
+    const matchEl = document.getElementById('ppol-match');
+    if (matchEl) {
+        if (conf.length > 0) {
+            matchEl.style.display = '';
+            const ok = pass === conf && pass.length > 0;
+            matchEl.style.color = ok ? 'var(--green-600)' : 'var(--red-500)';
+            matchEl.querySelector('i').className = ok ? 'bi bi-check-circle-fill' : 'bi bi-x-circle';
+        } else {
+            matchEl.style.display = 'none';
+        }
+    }
+    return rules.every(r => r.ok) && pass === conf;
+}
+
+async function changePassword() {
+    const oldPass = document.getElementById('profilOldPass').value;
+    const newPass = document.getElementById('profilNewPass').value;
+    const errEl = document.getElementById('profilPwError');
+    const successEl = document.getElementById('profilPwSuccess');
+    errEl.style.display = 'none';
+    successEl.style.display = 'none';
+
+    if (!oldPass) { errEl.textContent = 'Bitte aktuelles Passwort eingeben.'; errEl.style.display = ''; return; }
+    if (!checkProfilPwPolicy()) { errEl.textContent = 'Bitte alle Passwort-Anforderungen erfüllen.'; errEl.style.display = ''; return; }
+
+    const res = await fetch('/api/auth/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ altesPasswort: oldPass, neuesPasswort: newPass })
+    });
+    const data = await res.json().catch(() => null);
+    if (res.ok) {
+        successEl.textContent = 'Passwort erfolgreich geändert.';
+        successEl.style.display = '';
+        document.getElementById('profilOldPass').value = '';
+        document.getElementById('profilNewPass').value = '';
+        document.getElementById('profilNewPassConfirm').value = '';
+        resetProfilPwPolicy();
+    } else {
+        errEl.textContent = data?.error || 'Fehler beim Ändern des Passworts.';
+        errEl.style.display = '';
+    }
 }
 
 async function saveProfil() {

--- a/server.js
+++ b/server.js
@@ -762,6 +762,37 @@ app.put('/api/auth/profil', requireAuth, async (req, res) => {
   }
 });
 
+app.post('/api/auth/change-password', requireAuth, async (req, res) => {
+  try {
+    const userId = req.session.userId;
+    const oldPassword = req.body.altesPasswort || '';
+    const newPassword = req.body.neuesPasswort || '';
+
+    if (newPassword.length < 8) return res.status(400).json({ error: 'Passwort muss mindestens 8 Zeichen haben.' });
+    if (!/[A-Z]/.test(newPassword)) return res.status(400).json({ error: 'Passwort muss mindestens einen Grossbuchstaben enthalten.' });
+    if (!/[a-z]/.test(newPassword)) return res.status(400).json({ error: 'Passwort muss mindestens einen Kleinbuchstaben enthalten.' });
+    if (!/[^A-Za-z0-9]/.test(newPassword)) return res.status(400).json({ error: 'Passwort muss mindestens ein Sonderzeichen enthalten.' });
+
+    const db = await getPool();
+    const result = await db.request()
+      .input('uid', sql.Int, userId)
+      .query('SELECT PasswordHash FROM Benutzer WHERE Id=@uid');
+    if (result.recordset.length === 0) return res.status(404).json({ error: 'Benutzer nicht gefunden.' });
+
+    if (!verifyPassword(oldPassword, result.recordset[0].PasswordHash))
+      return res.status(400).json({ error: 'Aktuelles Passwort ist falsch.' });
+
+    await db.request()
+      .input('hash', sql.NVarChar, hashPassword(newPassword))
+      .input('uid', sql.Int, userId)
+      .query('UPDATE Benutzer SET PasswordHash=@hash WHERE Id=@uid');
+    res.json({ message: 'Passwort geändert.' });
+  } catch (err) {
+    console.error('change-password error:', err);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
+});
+
 // ==================== HAUSHALT ENDPOINTS ====================
 
 app.post('/api/haushalt', requireAuth, async (req, res) => {


### PR DESCRIPTION
## Summary
- Neuer Bereich im Profil-Modal zum Passwort ändern
- Aktuelles Passwort muss zur Verifizierung eingegeben werden
- Live-Passwort-Richtlinien-Checkliste (gleich wie bei Registrierung)
- Backend-Endpunkt `/api/auth/change-password`

## Test plan
- [ ] Passwort ändern mit korrektem alten Passwort
- [ ] Falsches altes Passwort wird abgelehnt
- [ ] Passwort-Richtlinien werden live angezeigt
- [ ] Felder werden beim Schliessen des Modals zurückgesetzt

🤖 Generated with [Claude Code](https://claude.com/claude-code)