### PR TITLE
Fix: PWA 404 - start_url korrigiert

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
     "name": "Einkaufsliste",
     "short_name": "Einkauf",
     "description": "Einkaufsliste mit Mengen, Kategorien und Fälligkeitsdatum",
-    "start_url": "./einkaufsliste.html",
+    "start_url": "./index.html",
     "display": "standalone",
     "background_color": "#f3f4f6",
     "theme_color": "#2563eb",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,17 @@
-const CACHE_NAME = 'einkaufsliste-v3';
+const CACHE_NAME = 'einkaufsliste-v4';
 const ASSETS = [
     './',
-    './einkaufsliste.html',
+    './index.html',
+    './register.html',
+    './reset.html',
+    './rezepte.html',
+    './wochenplan.html',
     './app.css',
     './app.js',
+    './shared.js',
+    './rezepte.js',
+    './wochenplan.js',
+    './wochenplan.css',
     './manifest.json',
     './icons/icon-192.svg',
     './icons/icon-512.svg',


### PR DESCRIPTION
start_url in manifest.json zeigte auf nicht existierende einkaufsliste.html statt index.html. Service Worker Cache aktualisiert.