### PR TITLE
Add anonymous bug reporting feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Eine Progressive Web App (PWA) für die gemeinsame Einkaufsplanung im Haushalt �
 - **Aktionen** — Aktuelle Angebote von Migros, Coop, Denner, Lidl und Aldi. Automatische Erkennung passender Aktionen für Artikel auf der Liste.
 - **Haushalt** — Haushalt erstellen, Mitglieder per Code einladen, gemeinsame Listen und Pläne. Rollenbasierter Zugriff (Lesen/Schreiben).
 - **PWA / Offline** — Als App auf dem Handy oder Desktop installierbar. Offline-Unterstützung via Service Worker.
+- **Bug melden** — Probleme direkt aus der App anonym melden. Die Meldung wird automatisch als GitHub Issue erstellt.
 
 ## Tech Stack
 
@@ -54,6 +55,9 @@ Der Server erwartet folgende Umgebungsvariablen:
 | `SMTP_FROM` | Absender-Adresse |
 | `BASE_URL` | Öffentliche URL der App |
 | `SESSION_SECRET` | Session-Secret |
+| `GITHUB_TOKEN` | GitHub Personal Access Token (für Bug-Reports) |
+| `GITHUB_OWNER` | GitHub Repository Owner (Standard: `surendiransithamparam`) |
+| `GITHUB_REPO` | GitHub Repository Name (Standard: `Einkaufsliste`) |
 
 ## Starten
 
@@ -106,7 +110,8 @@ Einkaufsliste/
 | Aktionen | `GET /api/aktionen` | Aktuelle Angebote |
 | Haushalt | `POST /api/haushalt` | Haushalt erstellen/beitreten |
 | Admin | `GET /api/admin/benutzer` | Benutzerverwaltung |
-| Health | `GET /health` | Health Check |
+| Bug Report | `POST /api/bugreport` | Anonymen Bug-Report erstellen |
+| Health | `GET /api/health` | Health Check |
 
 ## Sicherheit
 

--- a/public/about.html
+++ b/public/about.html
@@ -223,6 +223,11 @@
                 <strong>PWA / Offline</strong>
                 <span>Als App installierbar und offline nutzbar</span>
             </div>
+            <div class="feature-card">
+                <i class="bi bi-bug"></i>
+                <strong>Bug melden</strong>
+                <span>Probleme anonym direkt aus der App melden</span>
+            </div>
         </div>
     </div>
 
@@ -307,11 +312,118 @@
                 <i class="bi bi-github"></i> GitHub
             </a>
         </p>
+        <p style="margin-top:0.75rem">
+            <button class="btn btn-secondary" onclick="openBugReport()" style="font-size:0.85rem;padding:0.5rem 1.25rem;border:1px solid var(--gray-200);border-radius:var(--radius-sm);background:var(--surface);cursor:pointer;color:var(--gray-600)">
+                <i class="bi bi-bug"></i> Bug melden
+            </button>
+        </p>
     </div>
 
 </div>
 
 </div><!-- /app-content -->
+
+<!-- Bug Report Modal -->
+<div class="modal-overlay" id="bugReportOverlay" onclick="if(event.target===this)closeBugReport()" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:1000;justify-content:center;align-items:flex-end;padding:0">
+    <div style="background:var(--surface);border-radius:var(--radius) var(--radius) 0 0;width:100%;max-width:500px;margin:0 auto;max-height:90dvh;overflow-y:auto;padding:1.25rem;animation:slideUp .25s ease">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem">
+            <h2 style="font-size:1.1rem;margin:0;display:flex;align-items:center;gap:0.5rem;color:var(--gray-800)"><i class="bi bi-bug" style="color:var(--green-600)"></i> Bug melden</h2>
+            <button onclick="closeBugReport()" style="background:none;border:none;font-size:1.2rem;cursor:pointer;color:var(--gray-400);padding:0.25rem"><i class="bi bi-x-lg"></i></button>
+        </div>
+        <p style="font-size:0.82rem;color:var(--gray-500);margin-bottom:1rem">Deine Meldung wird anonym als GitHub Issue erstellt.</p>
+        <form onsubmit="submitBugReport(event)">
+            <label for="bugTitel" style="font-size:0.82rem;font-weight:600;color:var(--gray-700);display:block;margin-bottom:0.25rem">Titel *</label>
+            <input type="text" id="bugTitel" maxlength="100" required placeholder="Kurze Beschreibung des Problems" style="width:100%;padding:0.6rem;border:1px solid var(--gray-200);border-radius:var(--radius-sm);font-size:0.88rem;margin-bottom:0.75rem;box-sizing:border-box">
+
+            <label for="bugBeschreibung" style="font-size:0.82rem;font-weight:600;color:var(--gray-700);display:block;margin-bottom:0.25rem">Beschreibung *</label>
+            <textarea id="bugBeschreibung" maxlength="2000" rows="4" required placeholder="Was ist passiert? Was hast du erwartet?" style="width:100%;padding:0.6rem;border:1px solid var(--gray-200);border-radius:var(--radius-sm);font-size:0.88rem;margin-bottom:0.75rem;resize:vertical;font-family:inherit;box-sizing:border-box"></textarea>
+
+            <label for="bugSchritte" style="font-size:0.82rem;font-weight:600;color:var(--gray-700);display:block;margin-bottom:0.25rem">Schritte zum Reproduzieren</label>
+            <textarea id="bugSchritte" rows="3" placeholder="1. Gehe zu ...&#10;2. Klicke auf ...&#10;3. ..." style="width:100%;padding:0.6rem;border:1px solid var(--gray-200);border-radius:var(--radius-sm);font-size:0.88rem;margin-bottom:0.75rem;resize:vertical;font-family:inherit;box-sizing:border-box"></textarea>
+
+            <label for="bugKontakt" style="font-size:0.82rem;font-weight:600;color:var(--gray-700);display:block;margin-bottom:0.25rem">Kontakt (optional)</label>
+            <input type="email" id="bugKontakt" placeholder="E-Mail für Rückfragen" style="width:100%;padding:0.6rem;border:1px solid var(--gray-200);border-radius:var(--radius-sm);font-size:0.88rem;margin-bottom:0.75rem;box-sizing:border-box">
+
+            <div id="bugError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
+
+            <button type="submit" id="bugSubmitBtn" style="width:100%;padding:0.7rem;background:var(--green-600);color:#fff;border:none;border-radius:var(--radius-sm);font-size:0.9rem;font-weight:600;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:0.4rem">
+                <i class="bi bi-send"></i> Absenden
+            </button>
+        </form>
+    </div>
+</div>
+
+<!-- Toast Container -->
+<div id="toasts" style="position:fixed;top:1rem;left:50%;transform:translateX(-50%);z-index:2000;display:flex;flex-direction:column;gap:0.5rem;pointer-events:none"></div>
+
+<style>
+@keyframes slideUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+@keyframes toastIn { from { opacity:0; transform:translateY(-10px); } to { opacity:1; transform:translateY(0); } }
+</style>
+
+<script>
+function openBugReport() {
+    document.getElementById('bugTitel').value = '';
+    document.getElementById('bugBeschreibung').value = '';
+    document.getElementById('bugSchritte').value = '';
+    document.getElementById('bugKontakt').value = '';
+    document.getElementById('bugError').style.display = 'none';
+    document.getElementById('bugSubmitBtn').disabled = false;
+    const overlay = document.getElementById('bugReportOverlay');
+    overlay.style.display = 'flex';
+    setTimeout(() => document.getElementById('bugTitel').focus(), 200);
+}
+
+function closeBugReport() {
+    document.getElementById('bugReportOverlay').style.display = 'none';
+}
+
+function showToast(msg) {
+    const el = document.createElement('div');
+    el.style.cssText = 'background:var(--green-600);color:#fff;padding:0.6rem 1.2rem;border-radius:var(--radius-sm);font-size:0.85rem;font-weight:500;animation:toastIn .3s ease;pointer-events:auto';
+    el.textContent = msg;
+    document.getElementById('toasts').appendChild(el);
+    setTimeout(() => el.remove(), 3000);
+}
+
+async function submitBugReport(e) {
+    e.preventDefault();
+    const btn = document.getElementById('bugSubmitBtn');
+    const errEl = document.getElementById('bugError');
+    errEl.style.display = 'none';
+    btn.disabled = true;
+    btn.innerHTML = '<i class="bi bi-hourglass-split"></i> Wird gesendet...';
+
+    try {
+        const res = await fetch('/api/bugreport', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                titel: document.getElementById('bugTitel').value.trim(),
+                beschreibung: document.getElementById('bugBeschreibung').value.trim(),
+                schritte: document.getElementById('bugSchritte').value.trim(),
+                kontakt: document.getElementById('bugKontakt').value.trim()
+            })
+        });
+        const data = await res.json();
+        if (res.ok) {
+            closeBugReport();
+            showToast('Bug-Report gesendet. Danke!');
+        } else {
+            errEl.textContent = data.error || 'Fehler beim Senden.';
+            errEl.style.display = '';
+        }
+    } catch {
+        errEl.textContent = 'Netzwerkfehler. Bitte versuche es erneut.';
+        errEl.style.display = '';
+    }
+
+    btn.disabled = false;
+    btn.innerHTML = '<i class="bi bi-send"></i> Absenden';
+}
+
+document.addEventListener('keydown', e => { if (e.key === 'Escape') closeBugReport(); });
+</script>
 
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -17,6 +17,11 @@ try {
 const connStr = process.env.DB_CONNECTION_STRING || config.connectionString || '';
 const adminPassword = config.adminPassword || '';
 const smtpConfig = config.smtp || {};
+const githubConfig = config.github || {
+  token: process.env.GITHUB_TOKEN || '',
+  owner: process.env.GITHUB_OWNER || 'surendiransithamparam',
+  repo: process.env.GITHUB_REPO || 'Einkaufsliste'
+};
 
 // --- SQL pool ---
 let pool;
@@ -471,6 +476,61 @@ app.get('/api/health', (req, res) => {
     os: `${process.platform} ${process.arch}`,
     arch: process.arch
   });
+});
+
+// ==================== BUG REPORT ====================
+
+app.post('/api/bugreport', async (req, res) => {
+  try {
+    if (isRateLimited(req, 'bugreport', 3, 600))
+      return res.status(429).json({ error: 'Zu viele Meldungen. Bitte warte einige Minuten.' });
+
+    if (!githubConfig.token || !githubConfig.owner || !githubConfig.repo)
+      return res.status(503).json({ error: 'Bug-Report ist nicht konfiguriert.' });
+
+    const { titel, beschreibung, schritte, kontakt } = req.body;
+
+    if (!titel || !titel.trim() || titel.trim().length > 100)
+      return res.status(400).json({ error: 'Titel ist erforderlich (max. 100 Zeichen).' });
+    if (!beschreibung || !beschreibung.trim() || beschreibung.trim().length > 2000)
+      return res.status(400).json({ error: 'Beschreibung ist erforderlich (max. 2000 Zeichen).' });
+
+    const parts = [`## Beschreibung\n\n${beschreibung.trim()}`];
+    if (schritte && schritte.trim()) parts.push(`## Schritte zum Reproduzieren\n\n${schritte.trim()}`);
+    if (kontakt && kontakt.trim()) parts.push(`## Kontakt\n\n${kontakt.trim()}`);
+    const ua = req.headers['user-agent'] || 'Unbekannt';
+    parts.push(`---\n_Gemeldet via App am ${new Date().toISOString()}_\n_User-Agent: ${ua}_`);
+
+    const ghRes = await fetch(
+      `https://api.github.com/repos/${githubConfig.owner}/${githubConfig.repo}/issues`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${githubConfig.token}`,
+          'Accept': 'application/vnd.github+json',
+          'Content-Type': 'application/json',
+          'User-Agent': 'Einkaufsliste-App'
+        },
+        body: JSON.stringify({
+          title: `[Bug] ${titel.trim()}`,
+          body: parts.join('\n\n'),
+          labels: ['bug', 'user-report']
+        })
+      }
+    );
+
+    if (!ghRes.ok) {
+      const errText = await ghRes.text();
+      console.error('GitHub API error:', ghRes.status, errText);
+      return res.status(502).json({ error: 'Fehler beim Erstellen des Bug-Reports.' });
+    }
+
+    const issue = await ghRes.json();
+    res.json({ success: true, issueNumber: issue.number });
+  } catch (err) {
+    console.error('bugreport error:', err);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
 });
 
 // ==================== AUTH ENDPOINTS ====================


### PR DESCRIPTION
## Summary
- Users can report bugs anonymously from the About page via a modal form
- Reports are created as GitHub Issues using a server-side token (no GitHub account needed)
- New `POST /api/bugreport` endpoint with rate limiting (3 reports per 10 min per IP)
- README and About page updated with feature documentation

## Test plan
- [ ] Open About page, click "Bug melden" button
- [ ] Fill out form and submit → verify GitHub Issue is created with labels `bug` + `user-report`
- [ ] Submit 4 times within 10 min → verify rate limit error (429)
- [ ] Test without GitHub config → verify 503 error
- [ ] Test with empty title/description → verify validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)