### PR TITLE
Add merge-to-release workflow

### DIFF
--- a/.github/workflows/merge-to-release.yml
+++ b/.github/workflows/merge-to-release.yml
@@ -1,0 +1,40 @@
+name: Merge develop → release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes
+        id: diff
+        run: |
+          COMMITS=$(git rev-list --count origin/release..origin/develop)
+          echo "commits=$COMMITS" >> "$GITHUB_OUTPUT"
+          if [ "$COMMITS" -eq 0 ]; then
+            echo "No new commits to merge."
+          else
+            echo "$COMMITS new commit(s) to merge."
+          fi
+
+      - name: Create Pull Request
+        if: steps.diff.outputs.commits != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list --base release --head develop --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists."
+          else
+            gh pr create \
+              --title "Release: merge develop → release" \
+              --body "Automated PR to merge all changes from \`develop\` into \`release\`." \
+              --base release \
+              --head develop
+          fi


### PR DESCRIPTION
## Summary
- Adds a manually triggered GitHub Action (`workflow_dispatch`) that creates a PR from `develop` to `release`
- Respects branch protection rules by creating a PR instead of pushing directly
- Checks for new commits before creating a PR
- Prevents duplicate PRs if one already exists

## Test plan
- [ ] Merge this PR, then go to Actions > "Merge develop → release" > Run workflow
- [ ] Verify a PR from `develop` to `release` is created
- [ ] Run again → verify no duplicate PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)