### PR TITLE
Fix merge-to-release workflow permissions

### DIFF
--- a/.github/workflows/merge-to-release.yml
+++ b/.github/workflows/merge-to-release.yml
@@ -3,6 +3,10 @@ name: Merge develop → release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   create-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions` block to the merge-to-release workflow
- `pull-requests: write` allows the `GITHUB_TOKEN` to create PRs
- Fixes: `Resource not accessible by integration (createPullRequest)`

## Test plan
- [ ] Merge this PR, then run Actions > "Merge develop → release"
- [ ] Verify the PR from develop to release is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)