### PR TITLE
Fix: Artikel als gekauft markieren wird nicht persistiert

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -638,6 +638,7 @@ input:focus, select:focus {
     border: 1px solid var(--gray-200);
 }
 .toast.success { background: var(--green-600); color: white; border-color: transparent; }
+.toast.error { background: #dc3545; color: white; border-color: transparent; }
 @keyframes fadeInUp {
     from { opacity: 0; transform: translateY(10px); }
     to { opacity: 1; transform: translateY(0); }

--- a/public/app.js
+++ b/public/app.js
@@ -59,13 +59,26 @@ async function toggleGekauft(id) {
 
     if (!item.gekauft) {
         item.gekauft = true;
-        await fetch(`/api/artikel/${id}`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(item)
-        });
-        toast(`\u00AB${item.artikel}\u00BB erledigt`);
         renderList();
+        try {
+            const res = await fetch(`/api/artikel/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(item)
+            });
+            if (!res.ok) {
+                item.gekauft = false;
+                renderList();
+                toast('Fehler beim Speichern', true);
+                return;
+            }
+        } catch (e) {
+            item.gekauft = false;
+            renderList();
+            toast('Netzwerkfehler – bitte erneut versuchen', true);
+            return;
+        }
+        toast(`\u00AB${item.artikel}\u00BB erledigt`);
     } else {
         reactivateTargetId = id;
         document.getElementById('reactivateName').textContent = `\u00AB${item.artikel}\u00BB`;
@@ -89,18 +102,37 @@ async function confirmReactivate(useNewDate) {
     if (reactivateTargetId === null) return;
     const item = items.find(i => i.id === reactivateTargetId);
     if (item) {
+        const prevGekauft = item.gekauft;
+        const prevDatum = item.datum;
         item.gekauft = false;
         if (useNewDate) {
             const newDate = document.getElementById('reactivateDate').value;
             item.datum = newDate || '';
         }
-        await fetch(`/api/artikel/${item.id}`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(item)
-        });
-        toast(`\u00AB${item.artikel}\u00BB wieder offen`);
         renderList();
+        try {
+            const res = await fetch(`/api/artikel/${item.id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(item)
+            });
+            if (!res.ok) {
+                item.gekauft = prevGekauft;
+                item.datum = prevDatum;
+                renderList();
+                toast('Fehler beim Speichern', true);
+                closeReactivate();
+                return;
+            }
+        } catch (e) {
+            item.gekauft = prevGekauft;
+            item.datum = prevDatum;
+            renderList();
+            toast('Netzwerkfehler – bitte erneut versuchen', true);
+            closeReactivate();
+            return;
+        }
+        toast(`\u00AB${item.artikel}\u00BB wieder offen`);
     }
     closeReactivate();
 }

--- a/public/shared.js
+++ b/public/shared.js
@@ -82,9 +82,9 @@ async function logout() {
 }
 
 // -- Toast --
-function toast(msg) {
+function toast(msg, isError) {
     const el = document.createElement('div');
-    el.className = 'toast success';
+    el.className = isError ? 'toast error' : 'toast success';
     el.textContent = msg;
     document.getElementById('toasts').appendChild(el);
     setTimeout(() => el.remove(), 2500);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'einkaufsliste-v7';
+const CACHE_NAME = 'einkaufsliste-v8';
 const ASSETS = [
     './',
     './index.html',
@@ -39,12 +39,16 @@ self.addEventListener('activate', e => {
     );
 });
 
-// Fetch: network first, fallback to cache
+// Fetch: network first, fallback to cache (only cache GET requests)
 self.addEventListener('fetch', e => {
+    if (e.request.method !== 'GET') {
+        e.respondWith(fetch(e.request));
+        return;
+    }
     e.respondWith(
         fetch(e.request)
             .then(response => {
-                // Cache successful responses
+                // Cache successful GET responses
                 if (response.ok) {
                     const clone = response.clone();
                     caches.open(CACHE_NAME).then(cache => cache.put(e.request, clone));


### PR DESCRIPTION
## Summary
- Fixes #84: Artikel werden beim Markieren als "gekauft" nur lokal aktualisiert, aber bei fehlgeschlagenem PUT-Request nicht zurückgesetzt
- Rollback des lokalen States bei Server- oder Netzwerkfehlern mit Error-Toast für User-Feedback
- Service Worker cached nur noch GET-Requests (PUT/DELETE werden direkt ans Netzwerk weitergeleitet), Cache-Version auf v8 erhöht

## Test plan
- [ ] Artikel als gekauft markieren → bleibt nach Page-Refresh als gekauft
- [ ] Netzwerk unterbrechen, Artikel als gekauft markieren → roter Error-Toast, Artikel wird zurückgesetzt
- [ ] Gekauften Artikel reaktivieren → bleibt nach Page-Refresh als offen
- [ ] Service Worker Update: alte SW-Version wird durch v8 ersetzt

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)