### PR TITLE
Fix: Artikel löschen wird nicht persistiert

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -638,6 +638,7 @@ input:focus, select:focus {
     border: 1px solid var(--gray-200);
 }
 .toast.success { background: var(--green-600); color: white; border-color: transparent; }
+.toast.error { background: #dc3545; color: white; border-color: transparent; }
 @keyframes fadeInUp {
     from { opacity: 0; transform: translateY(10px); }
     to { opacity: 1; transform: translateY(0); }

--- a/public/app.js
+++ b/public/app.js
@@ -115,7 +115,16 @@ function toggleGekauftSection() {
 async function clearGekauft() {
     const count = items.filter(i => i.gekauft).length;
     if (count === 0) return;
-    await fetch('/api/artikel/gekauft', { method: 'DELETE' });
+    try {
+        const res = await fetch('/api/artikel/gekauft', { method: 'DELETE' });
+        if (!res.ok) {
+            toast('Fehler beim L\u00F6schen', true);
+            return;
+        }
+    } catch (e) {
+        toast('Netzwerkfehler \u2013 bitte erneut versuchen', true);
+        return;
+    }
     items = items.filter(i => !i.gekauft);
     toast(`${count} gekaufte Artikel entfernt`);
     renderList();
@@ -201,7 +210,18 @@ function closeDelete() { document.getElementById('deleteOverlay').classList.remo
 async function confirmDelete() {
     if (deleteTargetId !== null) {
         const item = items.find(i => i.id === deleteTargetId);
-        await fetch(`/api/artikel/${deleteTargetId}`, { method: 'DELETE' });
+        try {
+            const res = await fetch(`/api/artikel/${deleteTargetId}`, { method: 'DELETE' });
+            if (!res.ok) {
+                toast('Fehler beim L\u00F6schen', true);
+                closeDelete();
+                return;
+            }
+        } catch (e) {
+            toast('Netzwerkfehler \u2013 bitte erneut versuchen', true);
+            closeDelete();
+            return;
+        }
         items = items.filter(i => i.id !== deleteTargetId);
         toast(`\u00AB${item?.artikel}\u00BB gel\u00F6scht`);
         renderList();

--- a/public/shared.js
+++ b/public/shared.js
@@ -82,9 +82,9 @@ async function logout() {
 }
 
 // -- Toast --
-function toast(msg) {
+function toast(msg, isError) {
     const el = document.createElement('div');
-    el.className = 'toast success';
+    el.className = isError ? 'toast error' : 'toast success';
     el.textContent = msg;
     document.getElementById('toasts').appendChild(el);
     setTimeout(() => el.remove(), 2500);


### PR DESCRIPTION
## Summary
- Fixes #85: Gelöschte Artikel erscheinen nach Page-Refresh wieder
- Error-Handling für `confirmDelete()` und `clearGekauft()` – lokaler State wird nur bei erfolgreichem Server-Response aktualisiert
- Error-Toast bei Server- oder Netzwerkfehlern

## Test plan
- [ ] Artikel löschen → bleibt nach Page-Refresh gelöscht
- [ ] Netzwerk unterbrechen, Artikel löschen → roter Error-Toast, Artikel bleibt in der Liste
- [ ] Alle gekauften Artikel löschen → bleibt nach Refresh gelöscht

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)