### PR TITLE
Fix: About-Link im Menü zeigt keinen Text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -56,7 +56,7 @@
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden
                 </button>
-                <a href="about.html" style="text-decoration:none;color:inherit">
+                <a href="about.html" style="text-decoration:none">
                     <i class="bi bi-info-circle"></i> Über
                 </a>
             </div>

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -107,7 +107,7 @@
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden
                 </button>
-                <a href="about.html" style="text-decoration:none;color:inherit">
+                <a href="about.html" style="text-decoration:none">
                     <i class="bi bi-info-circle"></i> Über
                 </a>
             </div>

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -47,7 +47,7 @@
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden
                 </button>
-                <a href="about.html" style="text-decoration:none;color:inherit">
+                <a href="about.html" style="text-decoration:none">
                     <i class="bi bi-info-circle"></i> Über
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- Fixes #86: Im Dreipunkte-Menü war beim About-Eintrag nur das Icon sichtbar, der Text "Über" fehlte
- Ursache: `color:inherit` im inline-Style erbte `white` von der Navbar → weisser Text auf weissem Dropdown-Hintergrund
- Fix auf allen drei Seiten: index.html, rezepte.html, wochenplan.html

## Test plan
- [ ] Dreipunkte-Menü öffnen → "Über" Text ist neben dem Icon sichtbar
- [ ] Auf Rezepte-Seite prüfen → gleicher Fix
- [ ] Auf Wochenplan-Seite prüfen → gleicher Fix

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)