### PR TITLE
Fix: IIS WebDAV blockiert PUT/DELETE für Artikel-Mutation

### DIFF
--- a/web.config
+++ b/web.config
@@ -2,8 +2,12 @@
 <configuration>
   <system.webServer>
     <handlers>
+      <remove name="WebDAV" />
       <add name="iisnode" path="server.js" verb="*" modules="iisnode" />
     </handlers>
+    <modules>
+      <remove name="WebDAVModule" />
+    </modules>
     <rewrite>
       <rules>
         <rule name="iisnode-logs" stopProcessing="true">


### PR DESCRIPTION
## Summary
- IIS WebDAV-Modul fängt PUT und DELETE Requests ab, bevor sie an iisnode/Node.js weitergeleitet werden → `405 Method Not Allowed`
- Artikel können nach dem Erstellen nicht mehr bearbeitet, als gekauft markiert, Datum geändert oder gelöscht werden
- Fix: WebDAV-Handler und WebDAV-Modul in `web.config` explizit entfernen

## Test plan
- [ ] Artikel erstellen und danach bearbeiten (Name, Menge, Laden, Datum ändern)
- [ ] Artikel als gekauft markieren und wieder reaktivieren
- [ ] Artikel löschen
- [ ] Alle gekauften Artikel löschen

🤖 Generated with [Claude Code](https://claude.com/claude-code)