### PR TITLE
Add Admin CRUD für Laden-Verwaltung

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -99,6 +99,23 @@
             </table>
         </div>
     </div>
+
+    <div style="display:flex;justify-content:space-between;align-items:center;margin:1.5rem 0 1rem">
+        <h2 style="font-size:1.1rem;margin:0;color:var(--gray-700)"><i class="bi bi-shop"></i> Läden</h2>
+        <button class="btn btn-primary btn-sm" onclick="addLaden()"><i class="bi bi-plus-lg"></i> Neuer Laden</button>
+    </div>
+    <div class="table-wrap">
+        <table class="admin-table">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody id="ladenTableBody"></tbody>
+        </table>
+    </div>
 </div>
 </div>
 
@@ -171,6 +188,7 @@ function showApp() {
     document.getElementById('logoutBtn').style.display = '';
     loadUsers();
     loadHaushalte();
+    loadLaden();
 }
 
 function showLogin() {
@@ -398,6 +416,59 @@ async function deleteHaushalt(id, name) {
     toast('Haushalt gelöscht');
     closeHaushaltDetail();
     loadHaushalte();
+}
+
+// -- Läden --
+let laden = [];
+
+async function loadLaden() {
+    const res = await fetch('/api/laden');
+    if (!res.ok) return;
+    laden = await res.json();
+    renderLaden();
+}
+
+function renderLaden() {
+    const tbody = document.getElementById('ladenTableBody');
+    tbody.innerHTML = laden.map(l => `<tr>
+        <td>${l.id}</td>
+        <td><strong>${esc(l.name)}</strong></td>
+        <td>
+            <div class="admin-actions">
+                <button onclick="renameLaden(${l.id},'${esc(l.name).replace(/'/g,"\\'")}')" title="Umbenennen"><i class="bi bi-pencil"></i></button>
+                <button class="danger" onclick="deleteLaden(${l.id},'${esc(l.name).replace(/'/g,"\\'")}')" title="Löschen"><i class="bi bi-trash"></i></button>
+            </div>
+        </td>
+    </tr>`).join('');
+}
+
+async function addLaden() {
+    const name = prompt('Name des neuen Ladens:');
+    if (!name || !name.trim()) return;
+    const res = await fetch('/api/admin/laden', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim() })
+    });
+    if (res.ok) { toast('Laden erstellt'); loadLaden(); }
+    else { const d = await res.json().catch(()=>null); toast(d?.error || 'Fehler'); }
+}
+
+async function renameLaden(id, currentName) {
+    const newName = prompt('Neuer Name:', currentName);
+    if (!newName || newName.trim() === currentName) return;
+    const res = await fetch('/api/admin/laden/' + id, {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim() })
+    });
+    if (res.ok) { toast('Laden umbenannt'); loadLaden(); }
+    else { const d = await res.json().catch(()=>null); toast(d?.error || 'Fehler'); }
+}
+
+async function deleteLaden(id, name) {
+    if (!confirm('Laden \"' + name + '\" wirklich löschen?')) return;
+    const res = await fetch('/api/admin/laden/' + id, { method: 'DELETE' });
+    if (res.ok) { toast('Laden gelöscht'); loadLaden(); }
+    else { const d = await res.json().catch(()=>null); toast(d?.error || 'Fehler'); }
 }
 
 function toggleNavDropdown(e) { e.stopPropagation(); document.getElementById('navDropdownMenu').classList.toggle('open'); }

--- a/server.js
+++ b/server.js
@@ -1032,7 +1032,7 @@ app.get('/api/laden', requireAuth, async (req, res) => {
   try {
     const db = await getPool();
     const result = await db.request()
-      .query('SELECT Id, Name FROM Laden ORDER BY Sortierung, Name');
+      .query('SELECT Id, Name FROM Laden ORDER BY Name');
     res.json(result.recordset.map(r => ({ id: r.Id, name: r.Name })));
   } catch (err) {
     console.error('laden error:', err);
@@ -1482,6 +1482,89 @@ app.delete('/api/admin/haushalte/:id', requireAuth, async (req, res) => {
     res.json({});
   } catch (err) {
     console.error('admin haushalte delete error:', err);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
+});
+
+// --- Admin Laden Endpoints ---
+
+app.post('/api/admin/laden', requireAuth, async (req, res) => {
+  try {
+    const userId = req.session.userId;
+    const db = await getPool();
+    if (!await isAdmin(userId, db)) return res.status(403).json({});
+
+    const name = (req.body.name || '').trim();
+    if (!name) return res.status(400).json({ error: 'Name darf nicht leer sein.' });
+
+    const dup = await db.request()
+      .input('name', sql.NVarChar, name)
+      .query('SELECT Id FROM Laden WHERE LOWER(Name)=LOWER(@name)');
+    if (dup.recordset.length > 0) return res.status(400).json({ error: 'Laden mit diesem Namen existiert bereits.' });
+
+    const result = await db.request()
+      .input('name', sql.NVarChar, name)
+      .query('INSERT INTO Laden (Name, Sortierung) VALUES (@name, 0); SELECT SCOPE_IDENTITY() AS id');
+    res.json({ id: result.recordset[0].id, name });
+  } catch (err) {
+    console.error('admin laden post error:', err);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
+});
+
+app.put('/api/admin/laden/:id', requireAuth, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const userId = req.session.userId;
+    const db = await getPool();
+    if (!await isAdmin(userId, db)) return res.status(403).json({});
+
+    const name = (req.body.name || '').trim();
+    if (!name) return res.status(400).json({ error: 'Name darf nicht leer sein.' });
+
+    const dup = await db.request()
+      .input('name', sql.NVarChar, name)
+      .input('id', sql.Int, id)
+      .query('SELECT Id FROM Laden WHERE LOWER(Name)=LOWER(@name) AND Id<>@id');
+    if (dup.recordset.length > 0) return res.status(400).json({ error: 'Laden mit diesem Namen existiert bereits.' });
+
+    await db.request()
+      .input('name', sql.NVarChar, name)
+      .input('id', sql.Int, id)
+      .query('UPDATE Laden SET Name=@name WHERE Id=@id');
+    res.json({});
+  } catch (err) {
+    console.error('admin laden put error:', err);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
+});
+
+app.delete('/api/admin/laden/:id', requireAuth, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const userId = req.session.userId;
+    const db = await getPool();
+    if (!await isAdmin(userId, db)) return res.status(403).json({});
+
+    const laden = await db.request()
+      .input('id', sql.Int, id)
+      .query('SELECT Name FROM Laden WHERE Id=@id');
+    if (laden.recordset.length === 0) return res.status(404).json({ error: 'Laden nicht gefunden.' });
+
+    const ladenName = laden.recordset[0].Name;
+    const articles = await db.request()
+      .input('name', sql.NVarChar, ladenName)
+      .query('SELECT COUNT(*) AS cnt FROM Artikel WHERE Laden=@name');
+    if (articles.recordset[0].cnt > 0) {
+      return res.status(400).json({ error: `Laden kann nicht gelöscht werden – ${articles.recordset[0].cnt} Artikel verknüpft.` });
+    }
+
+    await db.request()
+      .input('id', sql.Int, id)
+      .query('DELETE FROM Laden WHERE Id=@id');
+    res.json({});
+  } catch (err) {
+    console.error('admin laden delete error:', err);
     res.status(500).json({ error: 'Interner Fehler.' });
   }
 });


### PR DESCRIPTION
## Summary
- Backend: 3 neue Admin-Endpoints (POST/PUT/DELETE) für `/api/admin/laden` mit Duplikat-Prüfung (case-insensitive) und Artikel-Verknüpfungs-Check beim Löschen
- GET `/api/laden` sortiert neu alphabetisch (`ORDER BY Name`) statt nach Sortierung
- Frontend: Neue Läden-Sektion im Admin-Panel mit Tabelle, "Neuer Laden"-Button sowie Umbenennen/Löschen pro Zeile

## Test plan
- [ ] Admin-Panel öffnen → Laden-Tabelle wird alphabetisch sortiert angezeigt
- [ ] "Neuer Laden" → Name eingeben → erscheint in Tabelle
- [ ] Umbenennen → neuer Name wird angezeigt
- [ ] Löschen eines Ladens ohne Artikel → wird entfernt
- [ ] Löschen eines Ladens mit Artikeln → Fehlermeldung
- [ ] Duplikat-Name → Fehlermeldung
- [ ] Einkaufsliste → Laden-Dropdown zeigt neue Läden alphabetisch

🤖 Generated with [Claude Code](https://claude.com/claude-code)