### PR TITLE
Docs: README und About-Seite aktualisieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Eine Progressive Web App (PWA) für die gemeinsame Einkaufsplanung im Haushalt �
 - **Aktionen** — Aktuelle Angebote von Migros, Coop, Denner, Lidl und Aldi. Automatische Erkennung passender Aktionen für Artikel auf der Liste.
 - **Haushalt** — Haushalt erstellen, Mitglieder per Code einladen, gemeinsame Listen und Pläne. Rollenbasierter Zugriff (Lesen/Schreiben).
 - **PWA / Offline** — Als App auf dem Handy oder Desktop installierbar. Offline-Unterstützung via Service Worker.
-- **Bug melden** — Probleme direkt aus der App anonym melden. Die Meldung wird automatisch als GitHub Issue erstellt.
+- **Admin-Panel** — Benutzer-, Haushalte- und Laden-Verwaltung. Benutzer aktivieren/deaktivieren, Rollen zuweisen, Läden erstellen/umbenennen/löschen.
+- **Bug melden** — Probleme direkt aus der App anonym melden (auf jeder Seite via 3-Punkte-Menü). Die Meldung wird automatisch als GitHub Issue erstellt.
 
 ## Tech Stack
 
@@ -85,6 +86,7 @@ Einkaufsliste/
 │   ├── app.js             # Einkaufsliste-Logik
 │   ├── app.css            # Styles
 │   ├── shared.js          # Auth & gemeinsame Funktionen
+│   ├── bugreport.js       # Bug-Report-Dialog (alle Seiten)
 │   ├── wochenplan.js      # Wochenplan-Logik
 │   ├── wochenplan.css     # Wochenplan-Styles
 │   ├── rezepte.js         # Rezepte-Logik
@@ -110,6 +112,8 @@ Einkaufsliste/
 | Aktionen | `GET /api/aktionen` | Aktuelle Angebote |
 | Haushalt | `POST /api/haushalt` | Haushalt erstellen/beitreten |
 | Admin | `GET /api/admin/benutzer` | Benutzerverwaltung |
+| Admin | `GET /api/admin/haushalte` | Haushalte-Verwaltung |
+| Admin | `POST/PUT/DELETE /api/admin/laden` | Laden-Verwaltung (CRUD) |
 | Bug Report | `POST /api/bugreport` | Anonymen Bug-Report erstellen |
 | Health | `GET /api/health` | Health Check |
 

--- a/public/about.html
+++ b/public/about.html
@@ -224,6 +224,11 @@
                 <span>Als App installierbar und offline nutzbar</span>
             </div>
             <div class="feature-card">
+                <i class="bi bi-shield-lock"></i>
+                <strong>Admin-Panel</strong>
+                <span>Benutzer, Haushalte und Läden verwalten</span>
+            </div>
+            <div class="feature-card">
                 <i class="bi bi-bug"></i>
                 <strong>Bug melden</strong>
                 <span>Probleme anonym direkt aus der App melden</span>


### PR DESCRIPTION
## Summary
- Admin-Panel Feature (Benutzer-, Haushalte-, Laden-Verwaltung) in README und About-Seite dokumentiert
- Bug-Report Verfügbarkeit auf allen Seiten via 3-Punkte-Menü erwähnt
- `bugreport.js` in Projektstruktur ergänzt
- Admin Laden + Haushalte API-Endpoints in README API-Tabelle hinzugefügt
- About-Seite: Neue Feature-Card "Admin-Panel"

## Test plan
- [ ] README.md prüfen – neue Einträge korrekt
- [ ] About-Seite öffnen – Admin-Panel Feature-Card sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)