### PR TITLE
feat: Tanken zu Aktionen umbenennen, Einkaufsaktionen auf Aktionen-Seite verschieben

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,9 +64,9 @@ jobs:
             --arg sessionSecret "$SESSION_SECRET" \
             --arg ghToken "$GH_TOKEN_APP" \
             --arg ghOwner "${GH_OWNER:-surendiransithamparam}" \
-            --arg ghRepo "${GH_REPO:-Einkaufsliste}" \
+            --arg ghRepo "${GH_REPO:-HaushaltPLUS}" \
             --arg waRpId "${WEBAUTHN_RP_ID:-localhost}" \
-            --arg waRpName "${WEBAUTHN_RP_NAME:-Einkaufsliste}" \
+            --arg waRpName "${WEBAUTHN_RP_NAME:-HaushaltPLUS}" \
             --arg waOrigin "${WEBAUTHN_ORIGIN:-http://localhost:3000}" \
             '{
               connectionString: $db,
@@ -78,7 +78,7 @@ jobs:
                 user: $smtpUser,
                 password: $smtpPw,
                 from: $smtpUser,
-                fromName: "Einkaufsliste"
+                fromName: "HaushaltPLUS"
               },
               github: {
                 token: $ghToken,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "einkaufsliste",
+  "name": "haushaltplus",
   "version": "1.0.0",
-  "description": "Einkaufsliste Backend (Node.js)",
+  "description": "HaushaltPLUS Backend (Node.js)",
   "main": "server.js",
   "scripts": {
     "start": "node server.js"

--- a/public/about.html
+++ b/public/about.html
@@ -6,9 +6,9 @@
     <meta name="theme-color" content="#2563eb">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <meta name="apple-mobile-web-app-title" content="Einkauf">
-    <meta name="description" content="Über die Einkaufsliste-App">
-    <title>Über — Einkaufsliste</title>
+    <meta name="apple-mobile-web-app-title" content="Haushalt+">
+    <meta name="description" content="Über die HaushaltPLUS-App">
+    <title>Über — HaushaltPLUS</title>
 
     <!-- PWA -->
     <link rel="manifest" href="manifest.json">
@@ -161,15 +161,15 @@
     <!-- Hero -->
     <div class="about-hero">
         <i class="bi bi-cart3"></i>
-        <h1>Einkaufsliste</h1>
+        <h1>HaushaltPLUS</h1>
         <p>Deine smarte Einkaufs- und Essensplanungs-App</p>
     </div>
 
     <!-- Beschreibung -->
     <div class="about-section">
-        <h2><i class="bi bi-info-circle"></i> Was ist Einkaufsliste?</h2>
+        <h2><i class="bi bi-info-circle"></i> Was ist HaushaltPLUS?</h2>
         <p>
-            Einkaufsliste ist eine Progressive Web App (PWA) für die gemeinsame Einkaufsplanung
+            HaushaltPLUS ist eine Progressive Web App (PWA) für die gemeinsame Einkaufsplanung
             im Haushalt. Die App bietet weit mehr als eine einfache Liste: sie kombiniert
             Einkaufsverwaltung, Wochenplanung, Rezeptverwaltung und aktuelle Aktionen
             von Schweizer Detailhändlern in einer einzigen Anwendung.
@@ -283,7 +283,7 @@
     <div class="about-footer">
         <p>Version 1.0.0</p>
         <p style="margin-top:0.25rem">
-            <a href="https://github.com/surendiransithamparam/Einkaufsliste" target="_blank" rel="noopener">
+            <a href="https://github.com/surendiransithamparam/HaushaltPLUS" target="_blank" rel="noopener">
                 <i class="bi bi-github"></i> GitHub
             </a>
         </p>

--- a/public/admin.html
+++ b/public/admin.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Admin – Einkaufsliste</title>
+    <title>Admin – HaushaltPLUS</title>
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="app.css">

--- a/public/app.js
+++ b/public/app.js
@@ -3,7 +3,6 @@ async function showApp() {
     showAppBase();
     await loadStores();
     loadItems();
-    loadAktionenMatches();
 }
 
 // -- Data --
@@ -370,11 +369,8 @@ function renderTile(item) {
         if (s === 'overdue') badgeHtml = `<span class="tile-badge danger"><i class="bi bi-exclamation-triangle-fill"></i> \u00DCberf\u00E4llig</span>`;
         else if (s === 'today') badgeHtml = `<span class="tile-badge warn"><i class="bi bi-clock-fill"></i> Heute</span>`;
 
-        // Aktion badge
-        const aktionBadge = renderAktionBadge(item.id);
-
         const isGekauft = item.gekauft;
-        const tileCls = [cls, isGekauft ? 'gekauft' : '', aktionBadge ? 'has-aktion' : ''].filter(Boolean).join(' ');
+        const tileCls = [cls, isGekauft ? 'gekauft' : ''].filter(Boolean).join(' ');
         const checkIcon = isGekauft ? 'bi-check-circle-fill' : 'bi-circle';
         const doneBadge = isGekauft ? '<span class="tile-badge done"><i class="bi bi-check-lg"></i> Gekauft</span>' : badgeHtml;
 
@@ -393,7 +389,6 @@ function renderTile(item) {
                 <span class="tile-field-value large">${item.menge} ${esc(item.einheit)}</span>
                 ${item.laden ? `<span class="tile-field-value"><i class="bi bi-shop"></i> ${esc(item.laden)}</span>` : ''}
             </div>
-            ${aktionBadge ? `<div class="tile-aktion-row">${aktionBadge}</div>` : ''}
             <div class="tile-footer">
                 <div class="tile-date ${dateClass}">
                     <i class="bi bi-calendar3"></i>
@@ -537,166 +532,6 @@ function mapEinheit(e) {
     return map[e] || 'Stück';
 }
 
-// -- Aktionen --
-let aktionenMatches = {}; // { artikelId: [{name, preis, laden, ...}] }
-
-async function loadAktionenMatches() {
-    try {
-        const res = await fetch('/api/aktionen/match');
-        if (res.ok) {
-            aktionenMatches = await res.json();
-            const matchCount = Object.keys(aktionenMatches).length;
-            const badge = document.getElementById('aktionenCountBadge');
-            if (matchCount > 0) {
-                badge.textContent = matchCount;
-                badge.style.display = '';
-            } else {
-                badge.style.display = 'none';
-            }
-            renderList();
-        }
-    } catch (e) {
-        console.error('Aktionen-Match fehlgeschlagen', e);
-    }
-}
-
-function renderAktionBadge(itemId) {
-    const matches = aktionenMatches[itemId];
-    if (!matches || matches.length === 0) return '';
-    const first = matches[0];
-    const preisText = first.preis ? `CHF ${first.preis.toFixed(2)}` : '';
-    const ladenText = first.laden || '';
-    const countExtra = matches.length > 1 ? ` +${matches.length - 1}` : '';
-    return `<span class="tile-badge aktion" onclick="event.stopPropagation();showAktionDetail(${itemId})" title="Aktion gefunden!">
-        <i class="bi bi-tag-fill"></i> ${esc(ladenText)}${preisText ? ' ' + preisText : ''}${countExtra}
-    </span>`;
-}
-
-function showAktionDetail(itemId) {
-    const matches = aktionenMatches[itemId];
-    const item = items.find(i => i.id === itemId);
-    if (!matches || !item) return;
-
-    const container = document.getElementById('aktionenResults');
-    const status = document.getElementById('aktionenStatus');
-    status.textContent = `Aktionen f\u00FCr \u00AB${item.artikel}\u00BB`;
-    container.innerHTML = matches.map(a => renderAktionCard(a)).join('');
-    document.getElementById('aktionenSuche').value = item.artikel;
-    document.getElementById('aktionenOverlay').classList.add('active');
-}
-
-function renderAktionCard(a) {
-    const preisHtml = a.preis ? `<span class="aktion-preis">CHF ${a.preis.toFixed(2)}</span>` : '';
-    const origHtml = a.originalPreis ? `<span class="aktion-orig-preis">statt CHF ${a.originalPreis.toFixed(2)}</span>` : '';
-    const rabattHtml = a.rabatt ? `<span class="aktion-rabatt">${esc(a.rabatt)}</span>` : '';
-    const beschreibung = a.beschreibung ? `<div class="aktion-card-desc">${esc(a.beschreibung)}</div>` : '';
-    const gueltig = a.gueltigVon && a.gueltigBis
-        ? `<div class="aktion-card-gueltig"><i class="bi bi-calendar3"></i> ${a.gueltigVon.substring(8,10)}.${a.gueltigVon.substring(5,7)}. \u2013 ${a.gueltigBis.substring(8,10)}.${a.gueltigBis.substring(5,7)}.</div>`
-        : '';
-    return `<div class="aktion-card">
-        <div class="aktion-card-header">
-            <span class="aktion-laden"><i class="bi bi-shop"></i> ${esc(a.laden)}</span>
-            ${rabattHtml}
-        </div>
-        <div class="aktion-card-name">${esc(a.name)}</div>
-        ${beschreibung}
-        <div class="aktion-card-preis">${preisHtml} ${origHtml}</div>
-        ${gueltig}
-    </div>`;
-}
-
-function openAktionen() {
-    document.getElementById('aktionenSuche').value = '';
-    document.getElementById('aktionenLaden').value = '';
-    document.getElementById('aktionenResults').innerHTML = '<p style="color:var(--gray-400);font-size:0.85rem;text-align:center">Suche nach Produkten oder lade alle Aktionen...</p>';
-    document.getElementById('aktionenStatus').textContent = '';
-    document.getElementById('aktionenOverlay').classList.add('active');
-    setTimeout(() => document.getElementById('aktionenSuche').focus(), 200);
-    // Auto-load all aktionen overview
-    loadAktionenOverview();
-}
-
-function closeAktionen() {
-    document.getElementById('aktionenOverlay').classList.remove('active');
-}
-
-async function loadAktionenOverview() {
-    const container = document.getElementById('aktionenResults');
-    const status = document.getElementById('aktionenStatus');
-    try {
-        const res = await fetch('/api/aktionen/alle');
-        if (!res.ok) { container.innerHTML = '<p style="color:var(--red-500)">Fehler beim Laden.</p>'; return; }
-        const data = await res.json();
-        status.textContent = `${data.total} Aktionen geladen`;
-        if (data.total === 0) {
-            container.innerHTML = '<p style="color:var(--gray-500);font-size:0.85rem;text-align:center">Keine Aktionen gefunden. Die Daten werden beim ersten Aufruf geladen.</p>';
-            return;
-        }
-        let html = '';
-        for (const [laden, items] of Object.entries(data.byLaden)) {
-            html += `<div class="store-group-header" style="margin-top:0.75rem">
-                <span class="store-name"><i class="bi bi-shop"></i> ${esc(laden)}</span>
-                <span class="store-count">${items.length}</span>
-                <div class="store-line"></div>
-            </div>`;
-            html += items.slice(0, 10).map(a => renderAktionCard(a)).join('');
-            if (items.length > 10) {
-                html += `<p style="color:var(--gray-400);font-size:0.8rem;padding:0.25rem 0.5rem">... und ${items.length - 10} weitere</p>`;
-            }
-        }
-        container.innerHTML = html;
-    } catch (e) {
-        container.innerHTML = '<p style="color:var(--red-500)">Fehler beim Laden der Aktionen.</p>';
-    }
-}
-
-async function searchAktionen() {
-    const suche = document.getElementById('aktionenSuche').value.trim();
-    const laden = document.getElementById('aktionenLaden').value;
-    const container = document.getElementById('aktionenResults');
-    const status = document.getElementById('aktionenStatus');
-
-    if (!suche && !laden) { loadAktionenOverview(); return; }
-
-    container.innerHTML = '<p style="color:var(--gray-400);font-size:0.85rem">Suche...</p>';
-
-    const params = new URLSearchParams();
-    if (suche) params.set('suche', suche);
-    if (laden) params.set('laden', laden);
-
-    try {
-        const res = await fetch(`/api/aktionen?${params}`);
-        if (!res.ok) { container.innerHTML = '<p style="color:var(--red-500)">Suche fehlgeschlagen.</p>'; return; }
-        const data = await res.json();
-        status.textContent = `${data.length} Treffer`;
-        if (data.length === 0) {
-            container.innerHTML = '<p style="color:var(--gray-500);font-size:0.85rem;text-align:center">Keine Aktionen gefunden.</p>';
-            return;
-        }
-        container.innerHTML = data.map(a => renderAktionCard(a)).join('');
-    } catch (e) {
-        container.innerHTML = '<p style="color:var(--red-500)">Fehler bei der Suche.</p>';
-    }
-}
-
-async function refreshAktionen() {
-    const status = document.getElementById('aktionenStatus');
-    status.textContent = 'Aktionen werden neu geladen...';
-    try {
-        const res = await fetch('/api/aktionen/refresh', { method: 'POST' });
-        if (res.ok) {
-            const data = await res.json();
-            toast(`${data.total} Aktionen geladen`);
-            loadAktionenOverview();
-            loadAktionenMatches();
-        } else {
-            status.textContent = 'Fehler beim Aktualisieren.';
-        }
-    } catch (e) {
-        status.textContent = 'Fehler beim Aktualisieren.';
-    }
-}
-
 // -- Haushalt: logic is in shared.js --
 
 // -- Tile click (skip if long-press) --
@@ -763,7 +598,7 @@ document.addEventListener('pointerdown', e => {
 
 // -- Keyboard --
 document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') { closeModal(); closeDelete(); closeReactivate(); closeHaushalt(); closeRezept(); closeAktionen(); hideAllTileActions(); }
+    if (e.key === 'Escape') { closeModal(); closeDelete(); closeReactivate(); closeHaushalt(); closeRezept(); hideAllTileActions(); }
 });
 
 // -- PWA: Service Worker --

--- a/public/index.html
+++ b/public/index.html
@@ -6,9 +6,9 @@
     <meta name="theme-color" content="#2563eb">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <meta name="apple-mobile-web-app-title" content="Einkauf">
-    <meta name="description" content="Einkaufsliste mit Mengen, Kategorien und Fälligkeitsdatum">
-    <title>Einkaufsliste</title>
+    <meta name="apple-mobile-web-app-title" content="Haushalt+">
+    <meta name="description" content="HaushaltPLUS – Einkaufsliste, Wochenplan, Rezepte und mehr">
+    <title>HaushaltPLUS</title>
 
     <!-- PWA -->
     <link rel="manifest" href="manifest.json">
@@ -40,9 +40,9 @@
             <i class="bi bi-book"></i>
             <span>Rezepte</span>
         </a>
-        <a href="tankrabatte.html" class="nav-tab" title="Tankrabatte">
-            <i class="bi bi-fuel-pump"></i>
-            <span>Tanken</span>
+        <a href="tankrabatte.html" class="nav-tab" title="Aktionen">
+            <i class="bi bi-tag"></i>
+            <span>Aktionen</span>
         </a>
     </div>
     <div class="navbar-right">
@@ -101,10 +101,6 @@
                     <option value="artikel_asc">Artikel A–Z</option>
                     <option value="laden_asc">Laden</option>
                 </select>
-                <button class="btn btn-secondary btn-sm aktionen-btn" onclick="openAktionen()" title="Aktionen anzeigen">
-                    <i class="bi bi-tag"></i> <span class="aktionen-btn-label">Aktionen</span>
-                    <span class="aktionen-count" id="aktionenCountBadge" style="display:none">0</span>
-                </button>
             </div>
         </div>
     </div>
@@ -323,32 +319,6 @@
 
 <!-- Modal: Haushalt -->
 
-<!-- Modal: Aktionen -->
-<div class="modal-overlay" id="aktionenOverlay" onclick="if(event.target===this)closeAktionen()">
-    <div class="modal" style="max-width:600px">
-        <div class="modal-header">
-            <h2><i class="bi bi-tag"></i> Aktionen</h2>
-            <button class="modal-close" onclick="closeAktionen()"><i class="bi bi-x-lg"></i></button>
-        </div>
-        <div class="modal-body">
-            <div style="display:flex;gap:0.5rem;margin-bottom:1rem;flex-wrap:wrap">
-                <input type="text" id="aktionenSuche" placeholder="Produkt suchen…" onkeydown="if(event.key==='Enter')searchAktionen()" style="flex:1;min-width:120px">
-                <select id="aktionenLaden" onchange="searchAktionen()" style="min-width:100px">
-                    <option value="">Alle Läden</option>
-                    <option>Migros</option>
-                    <option>Coop</option>
-                    <option>Denner</option>
-                    <option>Lidl</option>
-                    <option>Aldi</option>
-                </select>
-                <button class="btn btn-primary btn-sm" onclick="searchAktionen()"><i class="bi bi-search"></i></button>
-                <button class="btn btn-secondary btn-sm" onclick="refreshAktionen()" title="Aktionen neu laden"><i class="bi bi-arrow-clockwise"></i></button>
-            </div>
-            <div id="aktionenStatus" style="font-size:0.75rem;color:var(--gray-400);margin-bottom:0.5rem"></div>
-            <div id="aktionenResults"></div>
-        </div>
-    </div>
-</div>
 
 </div><!-- /app-content -->
 
@@ -357,7 +327,7 @@
     <div class="login-card">
         <div class="login-header">
             <i class="bi bi-cart3" style="font-size:2.5rem;color:var(--green-600)"></i>
-            <h1 style="font-size:1.5rem;margin-top:0.5rem">Einkaufsliste</h1>
+            <h1 style="font-size:1.5rem;margin-top:0.5rem">HaushaltPLUS</h1>
             <p style="color:var(--gray-500);font-size:0.85rem;margin-top:0.25rem">Anmelden</p>
         </div>
         <form onsubmit="submitAuth(event)">

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-    "name": "Einkaufsliste",
-    "short_name": "Einkauf",
-    "description": "Einkaufsliste mit Mengen, Kategorien und Fälligkeitsdatum",
+    "name": "HaushaltPLUS",
+    "short_name": "Haushalt+",
+    "description": "HaushaltPLUS – Einkaufsliste, Wochenplan, Rezepte und mehr",
     "start_url": "./index.html",
     "display": "standalone",
     "background_color": "#f3f4f6",

--- a/public/register.html
+++ b/public/register.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Registrieren – Einkaufsliste</title>
+    <title>Registrieren – HaushaltPLUS</title>
     <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">

--- a/public/reset.html
+++ b/public/reset.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Passwort zurücksetzen – Einkaufsliste</title>
+    <title>Passwort zurücksetzen – HaushaltPLUS</title>
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="app.css">

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <title>Rezepte – Einkaufsliste</title>
+    <title>Rezepte – HaushaltPLUS</title>
     <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
@@ -88,9 +88,9 @@
             <i class="bi bi-book"></i>
             <span>Rezepte</span>
         </a>
-        <a href="tankrabatte.html" class="nav-tab" title="Tankrabatte">
-            <i class="bi bi-fuel-pump"></i>
-            <span>Tanken</span>
+        <a href="tankrabatte.html" class="nav-tab" title="Aktionen">
+            <i class="bi bi-tag"></i>
+            <span>Aktionen</span>
         </a>
     </div>
     <div class="navbar-right">

--- a/public/shared.js
+++ b/public/shared.js
@@ -262,7 +262,7 @@ async function openHaushalt() {
     } else {
         body.innerHTML = `
             <p style="color:var(--gray-500);font-size:0.85rem;margin-bottom:1.25rem">
-                Erstelle einen Haushalt oder tritt einem bei, um die Einkaufsliste zu teilen.
+                Erstelle einen Haushalt oder tritt einem bei, um Einkaufsliste, Wochenplan und Rezepte zu teilen.
             </p>
             <div style="margin-bottom:1.25rem">
                 <label>Neuen Haushalt erstellen</label>

--- a/public/tankrabatte.html
+++ b/public/tankrabatte.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Tankrabatte</title>
+    <title>Aktionen</title>
     <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
@@ -28,9 +28,9 @@
             <i class="bi bi-book"></i>
             <span>Rezepte</span>
         </a>
-        <a href="tankrabatte.html" class="nav-tab active" title="Tankrabatte">
-            <i class="bi bi-fuel-pump"></i>
-            <span>Tanken</span>
+        <a href="tankrabatte.html" class="nav-tab active" title="Aktionen">
+            <i class="bi bi-tag"></i>
+            <span>Aktionen</span>
         </a>
     </div>
     <div class="navbar-right">
@@ -61,8 +61,31 @@
 
 <div id="appContent" class="app-content hidden">
 <div class="container">
-    <h2 style="font-size:1.1rem;margin-bottom:1rem;display:flex;align-items:center;gap:0.4rem">
-        <i class="bi bi-fuel-pump" style="color:var(--green-600)"></i> Aktuelle Tankrabatte
+
+    <!-- Einkaufsaktionen -->
+    <h2 style="font-size:1.1rem;margin-bottom:0.75rem;display:flex;align-items:center;gap:0.4rem">
+        <i class="bi bi-tag" style="color:var(--green-600)"></i> Einkaufsaktionen
+    </h2>
+
+    <div style="display:flex;gap:0.5rem;margin-bottom:1rem;flex-wrap:wrap">
+        <input type="text" id="aktionenSuche" placeholder="Produkt suchen…" onkeydown="if(event.key==='Enter')searchAktionen()" style="flex:1;min-width:120px">
+        <select id="aktionenLaden" onchange="searchAktionen()" style="min-width:100px">
+            <option value="">Alle Läden</option>
+            <option>Migros</option>
+            <option>Coop</option>
+            <option>Denner</option>
+            <option>Lidl</option>
+            <option>Aldi</option>
+        </select>
+        <button class="btn btn-primary btn-sm" onclick="searchAktionen()"><i class="bi bi-search"></i></button>
+        <button class="btn btn-secondary btn-sm" onclick="refreshAktionen()" title="Aktionen neu laden"><i class="bi bi-arrow-clockwise"></i></button>
+    </div>
+    <div id="aktionenStatus" style="font-size:0.75rem;color:var(--gray-400);margin-bottom:0.5rem"></div>
+    <div id="aktionenResults"></div>
+
+    <!-- Tankrabatte -->
+    <h2 style="font-size:1.1rem;margin-top:2rem;margin-bottom:1rem;display:flex;align-items:center;gap:0.4rem">
+        <i class="bi bi-fuel-pump" style="color:var(--green-600)"></i> Tankrabatte
     </h2>
 
     <div id="tankrabatteLoading" style="text-align:center;padding:2rem;color:var(--gray-400)">
@@ -129,8 +152,8 @@
 <div id="loginScreen" class="login-screen">
     <div class="login-card">
         <div class="login-header">
-            <i class="bi bi-fuel-pump" style="font-size:2.5rem;color:var(--green-600)"></i>
-            <h1 style="font-size:1.5rem;margin-top:0.5rem">Tankrabatte</h1>
+            <i class="bi bi-tag" style="font-size:2.5rem;color:var(--green-600)"></i>
+            <h1 style="font-size:1.5rem;margin-top:0.5rem">Aktionen</h1>
             <p style="color:var(--gray-500);font-size:0.85rem;margin-top:0.25rem">Anmelden</p>
         </div>
         <form onsubmit="submitAuth(event)">

--- a/public/tankrabatte.js
+++ b/public/tankrabatte.js
@@ -1,9 +1,110 @@
-// Tankrabatte - Aktuelle Tankgutscheine anzeigen
+// Aktionen & Tankrabatte
 
 function showApp() {
     showAppBase();
     ladeGutscheine();
+    loadAktionenOverview();
 }
+
+// -- Einkaufsaktionen --
+
+function renderAktionCard(a) {
+    const preisHtml = a.preis ? `<span class="aktion-preis">CHF ${a.preis.toFixed(2)}</span>` : '';
+    const origHtml = a.originalPreis ? `<span class="aktion-orig-preis">statt CHF ${a.originalPreis.toFixed(2)}</span>` : '';
+    const rabattHtml = a.rabatt ? `<span class="aktion-rabatt">${esc(a.rabatt)}</span>` : '';
+    const beschreibung = a.beschreibung ? `<div class="aktion-card-desc">${esc(a.beschreibung)}</div>` : '';
+    const gueltig = a.gueltigVon && a.gueltigBis
+        ? `<div class="aktion-card-gueltig"><i class="bi bi-calendar3"></i> ${a.gueltigVon.substring(8,10)}.${a.gueltigVon.substring(5,7)}. \u2013 ${a.gueltigBis.substring(8,10)}.${a.gueltigBis.substring(5,7)}.</div>`
+        : '';
+    return `<div class="aktion-card">
+        <div class="aktion-card-header">
+            <span class="aktion-laden"><i class="bi bi-shop"></i> ${esc(a.laden)}</span>
+            ${rabattHtml}
+        </div>
+        <div class="aktion-card-name">${esc(a.name)}</div>
+        ${beschreibung}
+        <div class="aktion-card-preis">${preisHtml} ${origHtml}</div>
+        ${gueltig}
+    </div>`;
+}
+
+async function loadAktionenOverview() {
+    const container = document.getElementById('aktionenResults');
+    const status = document.getElementById('aktionenStatus');
+    try {
+        const res = await fetch('/api/aktionen/alle');
+        if (!res.ok) { container.innerHTML = '<p style="color:var(--red-500)">Fehler beim Laden.</p>'; return; }
+        const data = await res.json();
+        status.textContent = `${data.total} Aktionen geladen`;
+        if (data.total === 0) {
+            container.innerHTML = '<p style="color:var(--gray-500);font-size:0.85rem;text-align:center">Keine Aktionen gefunden. Die Daten werden beim ersten Aufruf geladen.</p>';
+            return;
+        }
+        let html = '';
+        for (const [laden, items] of Object.entries(data.byLaden)) {
+            html += `<div class="store-group-header" style="margin-top:0.75rem">
+                <span class="store-name"><i class="bi bi-shop"></i> ${esc(laden)}</span>
+                <span class="store-count">${items.length}</span>
+                <div class="store-line"></div>
+            </div>`;
+            html += items.slice(0, 10).map(a => renderAktionCard(a)).join('');
+            if (items.length > 10) {
+                html += `<p style="color:var(--gray-400);font-size:0.8rem;padding:0.25rem 0.5rem">... und ${items.length - 10} weitere</p>`;
+            }
+        }
+        container.innerHTML = html;
+    } catch (e) {
+        container.innerHTML = '<p style="color:var(--red-500)">Fehler beim Laden der Aktionen.</p>';
+    }
+}
+
+async function searchAktionen() {
+    const suche = document.getElementById('aktionenSuche').value.trim();
+    const laden = document.getElementById('aktionenLaden').value;
+    const container = document.getElementById('aktionenResults');
+    const status = document.getElementById('aktionenStatus');
+
+    if (!suche && !laden) { loadAktionenOverview(); return; }
+
+    container.innerHTML = '<p style="color:var(--gray-400);font-size:0.85rem">Suche...</p>';
+
+    const params = new URLSearchParams();
+    if (suche) params.set('suche', suche);
+    if (laden) params.set('laden', laden);
+
+    try {
+        const res = await fetch(`/api/aktionen?${params}`);
+        if (!res.ok) { container.innerHTML = '<p style="color:var(--red-500)">Suche fehlgeschlagen.</p>'; return; }
+        const data = await res.json();
+        status.textContent = `${data.length} Treffer`;
+        if (data.length === 0) {
+            container.innerHTML = '<p style="color:var(--gray-500);font-size:0.85rem;text-align:center">Keine Aktionen gefunden.</p>';
+            return;
+        }
+        container.innerHTML = data.map(a => renderAktionCard(a)).join('');
+    } catch (e) {
+        container.innerHTML = '<p style="color:var(--red-500)">Fehler bei der Suche.</p>';
+    }
+}
+
+async function refreshAktionen() {
+    const status = document.getElementById('aktionenStatus');
+    status.textContent = 'Aktionen werden neu geladen...';
+    try {
+        const res = await fetch('/api/aktionen/refresh', { method: 'POST' });
+        if (res.ok) {
+            const data = await res.json();
+            toast(`${data.total} Aktionen geladen`);
+            loadAktionenOverview();
+        } else {
+            status.textContent = 'Fehler beim Aktualisieren.';
+        }
+    } catch (e) {
+        status.textContent = 'Fehler beim Aktualisieren.';
+    }
+}
+
+// -- Tankrabatte --
 
 async function ladeGutscheine() {
     const loading = document.getElementById('tankrabatteLoading');

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -28,9 +28,9 @@
             <i class="bi bi-book"></i>
             <span>Rezepte</span>
         </a>
-        <a href="tankrabatte.html" class="nav-tab" title="Tankrabatte">
-            <i class="bi bi-fuel-pump"></i>
-            <span>Tanken</span>
+        <a href="tankrabatte.html" class="nav-tab" title="Aktionen">
+            <i class="bi bi-tag"></i>
+            <span>Aktionen</span>
         </a>
     </div>
     <div class="navbar-right">

--- a/server.js
+++ b/server.js
@@ -26,13 +26,13 @@ const smtpConfig = config.smtp || {};
 const githubConfig = config.github || {
   token: process.env.GITHUB_TOKEN || '',
   owner: process.env.GITHUB_OWNER || 'surendiransithamparam',
-  repo: process.env.GITHUB_REPO || 'Einkaufsliste'
+  repo: process.env.GITHUB_REPO || 'HaushaltPLUS'
 };
 
 // WebAuthn / FIDO2 Konfiguration
 const webauthnConfig = {
   rpID: process.env.WEBAUTHN_RP_ID || (config.webauthn && config.webauthn.rpId) || 'localhost',
-  rpName: process.env.WEBAUTHN_RP_NAME || (config.webauthn && config.webauthn.rpName) || 'Einkaufsliste',
+  rpName: process.env.WEBAUTHN_RP_NAME || (config.webauthn && config.webauthn.rpName) || 'HaushaltPLUS',
   origin: process.env.WEBAUTHN_ORIGIN || (config.webauthn && config.webauthn.origin) || 'http://localhost:3000'
 };
 
@@ -123,7 +123,7 @@ async function sendActivationEmail(email, username, token, req) {
   const user = smtpConfig.user || '';
   const pass = smtpConfig.password || '';
   const fromAddr = smtpConfig.from || user;
-  const fromName = smtpConfig.fromName || 'Einkaufsliste';
+  const fromName = smtpConfig.fromName || 'HaushaltPLUS';
 
   const baseUrl = `${req.protocol}://${req.get('host')}`;
   const link = `${baseUrl}/api/auth/aktivieren?token=${encodeURIComponent(token)}`;
@@ -137,7 +137,7 @@ ${link}
 Falls du dich nicht registriert hast, kannst du diese E-Mail ignorieren.
 
 Viele Grüsse
-Einkaufsliste`;
+HaushaltPLUS`;
 
   const transporter = nodemailer.createTransport({
     host, port,
@@ -148,7 +148,7 @@ Einkaufsliste`;
   await transporter.sendMail({
     from: `"${fromName}" <${fromAddr}>`,
     to: email,
-    subject: 'Einkaufsliste – E-Mail bestätigen',
+    subject: 'HaushaltPLUS – E-Mail bestätigen',
     text: body
   });
 }
@@ -522,7 +522,7 @@ app.post('/api/bugreport', async (req, res) => {
           'Authorization': `Bearer ${githubConfig.token}`,
           'Accept': 'application/vnd.github+json',
           'Content-Type': 'application/json',
-          'User-Agent': 'Einkaufsliste-App'
+          'User-Agent': 'HaushaltPLUS-App'
         },
         body: JSON.stringify({
           title: `[Bug] ${titel.trim()}`,
@@ -634,8 +634,8 @@ app.get('/api/auth/aktivieren', async (req, res) => {
       .input('token', sql.NVarChar, token)
       .query('UPDATE Benutzer SET EmailBestaetigt=1, AktivierungsToken=NULL WHERE AktivierungsToken=@token AND EmailBestaetigt=0');
 
-    const htmlOk = '<html><body style="font-family:sans-serif;text-align:center;padding:3rem"><h2 style="color:#22c55e">&#10003; E-Mail bestätigt!</h2><p>Dein Konto ist jetzt aktiv. Du kannst dich anmelden.</p><a href="/">Zur Einkaufsliste</a></body></html>';
-    const htmlFail = '<html><body style="font-family:sans-serif;text-align:center;padding:3rem"><h2 style="color:#ef4444">Link ungültig</h2><p>Dieser Aktivierungslink ist ungültig oder wurde bereits verwendet.</p><a href="/">Zur Einkaufsliste</a></body></html>';
+    const htmlOk = '<html><body style="font-family:sans-serif;text-align:center;padding:3rem"><h2 style="color:#22c55e">&#10003; E-Mail bestätigt!</h2><p>Dein Konto ist jetzt aktiv. Du kannst dich anmelden.</p><a href="/">Zur HaushaltPLUS</a></body></html>';
+    const htmlFail = '<html><body style="font-family:sans-serif;text-align:center;padding:3rem"><h2 style="color:#ef4444">Link ungültig</h2><p>Dieser Aktivierungslink ist ungültig oder wurde bereits verwendet.</p><a href="/">Zur HaushaltPLUS</a></body></html>';
 
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.send(result.rowsAffected[0] > 0 ? htmlOk : htmlFail);
@@ -711,7 +711,7 @@ app.post('/api/auth/reset-request', async (req, res) => {
       const user = smtpConfig.user || '';
       const pass = smtpConfig.password || '';
       const fromAddr = smtpConfig.from || user;
-      const fromName = smtpConfig.fromName || 'Einkaufsliste';
+      const fromName = smtpConfig.fromName || 'HaushaltPLUS';
 
       const baseUrl = `${req.protocol}://${req.get('host')}`;
       const link = `${baseUrl}/reset.html?token=${encodeURIComponent(token)}`;
@@ -727,7 +727,7 @@ Der Link ist 1 Stunde gültig.
 Falls du dies nicht angefordert hast, kannst du diese E-Mail ignorieren.
 
 Viele Grüsse
-Einkaufsliste`;
+HaushaltPLUS`;
 
       const transporter = nodemailer.createTransport({
         host, port,
@@ -738,7 +738,7 @@ Einkaufsliste`;
       await transporter.sendMail({
         from: `"${fromName}" <${fromAddr}>`,
         to: email,
-        subject: 'Einkaufsliste – Passwort zurücksetzen',
+        subject: 'HaushaltPLUS – Passwort zurücksetzen',
         text: body
       });
     } catch (ex) {


### PR DESCRIPTION
## Summary
- **Aktionen-Button auf Einkauf-Seite entfernt** (inkl. Modal und Matching-Badges auf Artikeln)
- **Tanken in Aktionen umbenannt** in der Navigation aller Seiten (Icon: Tag statt Fuel-Pump)
- **Einkaufsaktionen (Migros, Coop, Denner, Lidl, Aldi)** werden jetzt direkt auf der Aktionen-Seite angezeigt, mit Suche und Filter
- Tankrabatte bleiben als eigene Sektion unterhalb der Einkaufsaktionen erhalten

## Test plan
- [ ] Einkauf-Seite: kein Aktionen-Button mehr sichtbar
- [ ] Navigation zeigt auf allen Seiten "Aktionen" statt "Tanken" mit Tag-Icon
- [ ] Aktionen-Seite: Einkaufsaktionen werden geladen und angezeigt
- [ ] Aktionen-Seite: Suche und Laden-Filter funktionieren
- [ ] Aktionen-Seite: Tankrabatte werden weiterhin korrekt angezeigt
- [ ] Aktionen-Seite: Refresh-Button aktualisiert die Aktionen

🤖 Generated with [Claude Code](https://claude.com/claude-code)