### PR TITLE
fix: Aktionen Popup im Vordergrund mit transparentem Hintergrund

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -794,18 +794,14 @@ input:focus, select:focus {
 
 /* -- Aktion Popup -- */
 .aktion-popup {
-    position: absolute;
-    left: -1rem;
-    right: -1rem;
-    min-width: 320px;
-    top: 100%;
-    margin-top: 0.25rem;
-    background: rgba(255, 255, 255, 0.92);
-    backdrop-filter: blur(8px);
-    border: 1px solid var(--gray-200);
+    position: fixed;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(209, 213, 219, 0.5);
     border-radius: 0.75rem;
-    box-shadow: 0 4px 16px rgba(0,0,0,0.15);
-    z-index: 100;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+    z-index: 200;
     max-height: 280px;
     overflow-y: auto;
 }

--- a/public/app.js
+++ b/public/app.js
@@ -604,11 +604,21 @@ function toggleAktionPopup(event, itemId) {
         </div>
         <div class="aktion-popup-body">${html}</div>`;
 
-    // Position near the badge
+    // Position near the badge, append to body to escape tile stacking context
     const badge = event.currentTarget;
-    const tile = badge.closest('.tile');
-    tile.style.position = 'relative';
-    tile.appendChild(popup);
+    const rect = badge.getBoundingClientRect();
+    popup.style.minWidth = '300px';
+    popup.style.maxWidth = '360px';
+    popup.style.left = `${rect.left}px`;
+    document.body.appendChild(popup);
+
+    // Flip above badge if not enough space below
+    const popupHeight = popup.offsetHeight;
+    if (rect.bottom + 4 + popupHeight > window.innerHeight) {
+        popup.style.bottom = `${window.innerHeight - rect.top + 4}px`;
+    } else {
+        popup.style.top = `${rect.bottom + 4}px`;
+    }
 }
 
 // Close popup when clicking outside
@@ -618,6 +628,12 @@ document.addEventListener('click', e => {
         popup.remove();
     }
 });
+
+// Close popup on scroll (fixed positioning doesn't follow scroll)
+window.addEventListener('scroll', () => {
+    const popup = document.getElementById('aktionPopup');
+    if (popup) popup.remove();
+}, true);
 
 // -- Haushalt: logic is in shared.js --
 


### PR DESCRIPTION
## Summary
- Popup wird jetzt an `document.body` angehängt statt an die Tile → kein Stacking-Context-Problem mehr
- Glassmorphism-Hintergrund mit `backdrop-filter: blur(12px)` und halbtransparenter Farbe
- Automatisches Schliessen beim Scrollen (da `position: fixed`)
- Flip nach oben wenn unten kein Platz im Viewport ist

## Test plan
- [ ] Einkauf-Seite öffnen mit Artikeln die Aktionen-Badges haben
- [ ] Badge klicken → Popup muss **vor** allen Kacheln erscheinen
- [ ] Hintergrund ist halbtransparent mit Blur-Effekt
- [ ] Badge bei Kachel am unteren Rand klicken → Popup flippt nach oben
- [ ] Scrollen → Popup schliesst sich
- [ ] Ausserhalb klicken → Popup schliesst sich

🤖 Generated with [Claude Code](https://claude.com/claude-code)