### PR TITLE
feat: Artikel von Aktionen-Seite zum Einkauf hinzufügen

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -893,6 +893,31 @@ input:focus, select:focus {
     color: var(--gray-500);
     margin-bottom: 0.15rem;
 }
+.aktion-card-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.aktion-add-btn {
+    background: none;
+    border: 1px solid var(--green-600);
+    color: var(--green-600);
+    border-radius: 6px;
+    padding: 0.2rem 0.45rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+    flex-shrink: 0;
+}
+.aktion-add-btn:hover {
+    background: var(--green-600);
+    color: #fff;
+}
+.aktion-add-btn.added {
+    background: var(--green-600);
+    color: #fff;
+    cursor: default;
+}
 .aktion-card-gueltig {
     font-size: 0.72rem;
     color: var(--gray-400);

--- a/public/tankrabatte.js
+++ b/public/tankrabatte.js
@@ -32,7 +32,12 @@ function renderAktionCard(a) {
         </div>
         <div class="aktion-card-name">${esc(a.name)}</div>
         ${beschreibung}
-        <div class="aktion-card-preis">${preisHtml} ${origHtml}</div>
+        <div class="aktion-card-footer">
+            <div class="aktion-card-preis">${preisHtml} ${origHtml}</div>
+            <button class="aktion-add-btn" onclick="addToEinkauf('${esc(a.name).replace(/'/g, "\\'")}', '${esc(a.laden).replace(/'/g, "\\'")}', this)" title="Zum Einkauf hinzufügen">
+                <i class="bi bi-cart-plus"></i>
+            </button>
+        </div>
         ${gueltig}
     </div>`;
 }
@@ -110,6 +115,26 @@ async function refreshAktionen() {
         }
     } catch (e) {
         status.textContent = 'Fehler beim Aktualisieren.';
+    }
+}
+
+// -- Add Aktion to Einkauf --
+
+async function addToEinkauf(name, laden, btn) {
+    btn.disabled = true;
+    try {
+        const res = await fetch('/api/artikel', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ artikel: name, menge: 1, einheit: 'Stück', laden: laden, datum: '' })
+        });
+        if (!res.ok) throw new Error();
+        btn.innerHTML = '<i class="bi bi-check-lg"></i>';
+        btn.classList.add('added');
+        toast(`«${name}» zum Einkauf hinzugefügt`);
+    } catch (e) {
+        btn.disabled = false;
+        toast('Fehler beim Hinzufügen', true);
     }
 }
 


### PR DESCRIPTION
## Summary
- Neuer Warenkorb-Button auf jeder Aktion-Card auf der Aktionen-Seite
- Klick erstellt einen Einkauf-Artikel mit Name und Laden aus der Aktion, ohne Datum
- Button zeigt Häkchen nach erfolgreichem Hinzufügen

## Test plan
- [ ] Aktionen-Seite öffnen
- [ ] Warenkorb-Button auf einer Aktion-Card klicken
- [ ] Toast-Meldung «Artikel zum Einkauf hinzugefügt» erscheint
- [ ] Button zeigt Häkchen und ist deaktiviert
- [ ] Einkauf-Seite öffnen → Artikel ist vorhanden mit korrektem Laden, ohne Datum

🤖 Generated with [Claude Code](https://claude.com/claude-code)