### PR TITLE
feat: Aktionen-Seite Verbesserungen

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -838,12 +838,18 @@ input:focus, select:focus {
 }
 
 /* -- Aktion Cards (modal) -- */
+.aktion-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 0.5rem;
+}
 .aktion-card {
     background: var(--gray-50);
     border: 1px solid var(--gray-200);
     border-radius: var(--radius-sm);
     padding: 0.65rem 0.75rem;
-    margin-bottom: 0.5rem;
+    display: flex;
+    flex-direction: column;
 }
 .aktion-card-header {
     display: flex;

--- a/public/app.css
+++ b/public/app.css
@@ -490,6 +490,13 @@ input:focus, select:focus {
     gap: 0.5rem;
     padding: 0.6rem 0.25rem 0.2rem;
     margin-top: 0.25rem;
+    cursor: pointer;
+    user-select: none;
+}
+.store-toggle {
+    font-size: 0.75rem;
+    color: var(--gray-400);
+    transition: transform 0.15s;
 }
 .store-group-header:first-child {
     margin-top: 0;

--- a/public/tankrabatte.js
+++ b/public/tankrabatte.js
@@ -58,12 +58,14 @@ async function loadAktionenOverview() {
         let html = '';
         for (const [laden, items] of Object.entries(data.byLaden)) {
             if (items.length === 0) continue;
-            html += `<div class="store-group-header" style="margin-top:0.75rem">
+            const groupId = `store-${laden.replace(/[^a-zA-Z0-9]/g, '')}`;
+            html += `<div class="store-group-header" style="margin-top:0.75rem" onclick="toggleStoreGroup('${groupId}')" role="button">
+                <i class="bi bi-chevron-down store-toggle" id="${groupId}-icon"></i>
                 <span class="store-name"><i class="bi bi-shop"></i> ${esc(laden)}</span>
                 <span class="store-count">${items.length}</span>
                 <div class="store-line"></div>
             </div>`;
-            html += `<div class="aktion-grid">`;
+            html += `<div class="aktion-grid" id="${groupId}">`;
             html += items.map(a => renderAktionCard(a, false)).join('');
             html += `</div>`;
         }
@@ -116,6 +118,18 @@ async function refreshAktionen() {
         }
     } catch (e) {
         status.textContent = 'Fehler beim Aktualisieren.';
+    }
+}
+
+function toggleStoreGroup(groupId) {
+    const grid = document.getElementById(groupId);
+    const icon = document.getElementById(groupId + '-icon');
+    if (grid.style.display === 'none') {
+        grid.style.display = '';
+        icon.classList.replace('bi-chevron-right', 'bi-chevron-down');
+    } else {
+        grid.style.display = 'none';
+        icon.classList.replace('bi-chevron-down', 'bi-chevron-right');
     }
 }
 

--- a/public/tankrabatte.js
+++ b/public/tankrabatte.js
@@ -17,7 +17,7 @@ function showApp() {
 
 // -- Einkaufsaktionen --
 
-function renderAktionCard(a) {
+function renderAktionCard(a, showLaden) {
     const preisHtml = a.preis ? `<span class="aktion-preis">CHF ${a.preis.toFixed(2)}</span>` : '';
     const origHtml = a.originalPreis ? `<span class="aktion-orig-preis">statt CHF ${a.originalPreis.toFixed(2)}</span>` : '';
     const rabattHtml = a.rabatt ? `<span class="aktion-rabatt">${esc(a.rabatt)}</span>` : '';
@@ -25,9 +25,10 @@ function renderAktionCard(a) {
     const gueltig = a.gueltigVon && a.gueltigBis
         ? `<div class="aktion-card-gueltig"><i class="bi bi-calendar3"></i> ${a.gueltigVon.substring(8,10)}.${a.gueltigVon.substring(5,7)}. \u2013 ${a.gueltigBis.substring(8,10)}.${a.gueltigBis.substring(5,7)}.</div>`
         : '';
+    const ladenHtml = showLaden ? `<span class="aktion-laden"><i class="bi bi-shop"></i> ${esc(a.laden)}</span>` : '';
     return `<div class="aktion-card">
         <div class="aktion-card-header">
-            <span class="aktion-laden"><i class="bi bi-shop"></i> ${esc(a.laden)}</span>
+            ${ladenHtml}
             ${rabattHtml}
         </div>
         <div class="aktion-card-name">${a.url ? `<a href="${esc(a.url)}" target="_blank" rel="noopener">${esc(a.name)} <i class="bi bi-box-arrow-up-right" style="font-size:0.7rem"></i></a>` : esc(a.name)}</div>
@@ -62,7 +63,9 @@ async function loadAktionenOverview() {
                 <span class="store-count">${items.length}</span>
                 <div class="store-line"></div>
             </div>`;
-            html += items.slice(0, 10).map(a => renderAktionCard(a)).join('');
+            html += `<div class="aktion-grid">`;
+            html += items.slice(0, 10).map(a => renderAktionCard(a, false)).join('');
+            html += `</div>`;
             if (items.length > 10) {
                 html += `<p style="color:var(--gray-400);font-size:0.8rem;padding:0.25rem 0.5rem">... und ${items.length - 10} weitere</p>`;
             }
@@ -96,7 +99,7 @@ async function searchAktionen() {
             container.innerHTML = '<p style="color:var(--gray-500);font-size:0.85rem;text-align:center">Keine Aktionen gefunden.</p>';
             return;
         }
-        container.innerHTML = data.map(a => renderAktionCard(a)).join('');
+        container.innerHTML = `<div class="aktion-grid">${data.map(a => renderAktionCard(a, true)).join('')}</div>`;
     } catch (e) {
         container.innerHTML = '<p style="color:var(--red-500)">Fehler bei der Suche.</p>';
     }

--- a/public/tankrabatte.js
+++ b/public/tankrabatte.js
@@ -64,11 +64,8 @@ async function loadAktionenOverview() {
                 <div class="store-line"></div>
             </div>`;
             html += `<div class="aktion-grid">`;
-            html += items.slice(0, 10).map(a => renderAktionCard(a, false)).join('');
+            html += items.map(a => renderAktionCard(a, false)).join('');
             html += `</div>`;
-            if (items.length > 10) {
-                html += `<p style="color:var(--gray-400);font-size:0.8rem;padding:0.25rem 0.5rem">... und ${items.length - 10} weitere</p>`;
-            }
         }
         container.innerHTML = html;
     } catch (e) {


### PR DESCRIPTION
## Summary
- Aktionen als responsive Kachel-Grid statt Liste dargestellt
- Alle Aktionis.ch Läden hinzugefügt (Coop Megastore, OTTO'S, SPAR, Volg, Denner)
- Externe Links auf Artikelnamen zur Aktionsquelle
- Alle Aktionen pro Laden anzeigen (kein 10er-Limit mehr)
- Laden-Gruppen ein-/ausklappbar mit Chevron-Icon
- Leere Laden-Gruppen werden ausgeblendet

## Test plan
- [ ] Aktionen-Seite öffnen → Kachel-Grid pro Laden
- [ ] Laden-Titel klicken → Gruppe klappt ein/aus
- [ ] Artikelname mit Link klicken → externe Seite öffnet in neuem Tab
- [ ] Alle 9 Läden im Dropdown verfügbar
- [ ] Alle Aktionen werden geladen (kein Limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)