### PR TITLE
fix: Popup bleibt beim Scrollen offen

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -539,6 +539,22 @@ function mapEinheit(e) {
 
 // -- Aktionen --
 let aktionenMatches = {}; // { artikelId: [{name, preis, laden, ...}] }
+let aktionPopupBadge = null;
+
+function positionAktionPopup() {
+    const popup = document.getElementById('aktionPopup');
+    if (!popup || !aktionPopupBadge) return;
+    const rect = aktionPopupBadge.getBoundingClientRect();
+    popup.style.left = `${rect.left}px`;
+    popup.style.top = '';
+    popup.style.bottom = '';
+    const popupHeight = popup.offsetHeight;
+    if (rect.bottom + 4 + popupHeight > window.innerHeight) {
+        popup.style.bottom = `${window.innerHeight - rect.top + 4}px`;
+    } else {
+        popup.style.top = `${rect.bottom + 4}px`;
+    }
+}
 
 async function loadAktionenMatches() {
     try {
@@ -605,20 +621,11 @@ function toggleAktionPopup(event, itemId) {
         <div class="aktion-popup-body">${html}</div>`;
 
     // Position near the badge, append to body to escape tile stacking context
-    const badge = event.currentTarget;
-    const rect = badge.getBoundingClientRect();
+    aktionPopupBadge = event.currentTarget;
     popup.style.minWidth = '300px';
     popup.style.maxWidth = '360px';
-    popup.style.left = `${rect.left}px`;
     document.body.appendChild(popup);
-
-    // Flip above badge if not enough space below
-    const popupHeight = popup.offsetHeight;
-    if (rect.bottom + 4 + popupHeight > window.innerHeight) {
-        popup.style.bottom = `${window.innerHeight - rect.top + 4}px`;
-    } else {
-        popup.style.top = `${rect.bottom + 4}px`;
-    }
+    positionAktionPopup();
 }
 
 // Close popup when clicking outside
@@ -629,11 +636,8 @@ document.addEventListener('click', e => {
     }
 });
 
-// Close popup on scroll (fixed positioning doesn't follow scroll)
-window.addEventListener('scroll', () => {
-    const popup = document.getElementById('aktionPopup');
-    if (popup) popup.remove();
-}, true);
+// Reposition popup on scroll
+window.addEventListener('scroll', () => positionAktionPopup(), true);
 
 // -- Haushalt: logic is in shared.js --
 


### PR DESCRIPTION
## Summary
- Aktionen-Popup schliesst sich nicht mehr beim Scrollen
- Popup folgt der Badge-Position dynamisch beim Scrollen

## Test plan
- [ ] Einkauf-Seite öffnen, Aktionen-Badge klicken → Popup öffnet
- [ ] Scrollen → Popup bleibt offen und folgt der Badge
- [ ] Ausserhalb klicken → Popup schliesst sich

🤖 Generated with [Claude Code](https://claude.com/claude-code)