### PR TITLE
fix: Kein Laden Gruppe zuerst anzeigen auf Einkauf-Seite

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -414,8 +414,8 @@ function renderGrouped(list) {
     });
 
     const keys = Object.keys(groups).sort((a, b) => {
-        if (!a) return 1;
-        if (!b) return -1;
+        if (!a) return -1;
+        if (!b) return 1;
         return a.localeCompare(b);
     });
 


### PR DESCRIPTION
## Summary
- "Kein Laden" Gruppe wird jetzt als erste Kategorie angezeigt
- Danach folgen alle Läden alphabetisch sortiert

## Test plan
- [ ] Einkauf-Seite öffnen mit Artikeln ohne Laden und mit verschiedenen Läden
- [ ] "Kein Laden" erscheint als erste Gruppe
- [ ] Restliche Läden sind alphabetisch sortiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)