### PR TITLE
feat: Produktbilder auf Aktionen-Kacheln anzeigen

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -844,6 +844,19 @@ input:focus, select:focus {
     border-radius: 0.25rem;
 }
 
+.aktion-card-img {
+    margin: -0.65rem -0.75rem 0.5rem;
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+    overflow: hidden;
+    background: var(--gray-100);
+}
+.aktion-card-img img {
+    width: 100%;
+    height: 120px;
+    object-fit: contain;
+    display: block;
+}
+
 /* -- Aktion Cards (modal) -- */
 .aktion-grid {
     display: grid;

--- a/public/tankrabatte.js
+++ b/public/tankrabatte.js
@@ -26,7 +26,9 @@ function renderAktionCard(a, showLaden) {
         ? `<div class="aktion-card-gueltig"><i class="bi bi-calendar3"></i> ${a.gueltigVon.substring(8,10)}.${a.gueltigVon.substring(5,7)}. \u2013 ${a.gueltigBis.substring(8,10)}.${a.gueltigBis.substring(5,7)}.</div>`
         : '';
     const ladenHtml = showLaden ? `<span class="aktion-laden"><i class="bi bi-shop"></i> ${esc(a.laden)}</span>` : '';
+    const bildHtml = a.bild ? `<div class="aktion-card-img"><img src="${esc(a.bild)}" alt="${esc(a.name)}" loading="lazy"></div>` : '';
     return `<div class="aktion-card">
+        ${bildHtml}
         <div class="aktion-card-header">
             ${ladenHtml}
             ${rabattHtml}

--- a/server.js
+++ b/server.js
@@ -2475,6 +2475,9 @@ async function fetchAktionisDeals() {
           // Extract discount percentage
           const discountMatch = block.match(/(-?\d+)\s*%/);
 
+          // Extract image
+          const imgMatch = block.match(/<img[^>]*src="([^"]+)"/i);
+
           if (nameMatch) {
             const name = decodeHTMLEntities(nameMatch[1].trim());
             if (name.length > 2) {
@@ -2488,7 +2491,7 @@ async function fetchAktionisDeals() {
                 kategorie: null,
                 gueltigVon: null,
                 gueltigBis: null,
-                bild: null,
+                bild: imgMatch ? imgMatch[1] : null,
                 url: dealUrl ? (dealUrl.startsWith('http') ? dealUrl : `https://www.aktionis.ch${dealUrl}`) : null
               });
             }


### PR DESCRIPTION
## Summary
- Bilder aus Aktionis.ch Deal-Cards extrahieren (Migros, Coop, Lidl, Aldi, etc.)
- Denner-API liefert bereits Packshot-URLs
- Produktbild wird oben in jeder Aktionen-Kachel angezeigt
- Lazy-Loading für Performance

## Test plan
- [ ] Aktionen-Seite öffnen → Kacheln mit Bildern sichtbar (Denner + Aktionis)
- [ ] Aktionen ohne Bild werden normal ohne Bild dargestellt
- [ ] Bilder skalieren korrekt (object-fit: contain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)