### PR TITLE
feat: Navigation-Redesign, Profil-Seite & Letzte-Seite-Merken

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -135,20 +135,8 @@
 
 <!-- Navbar -->
 <nav class="navbar">
-    <div class="navbar-left"></div>
-    <div class="navbar-center">
-        <a href="index.html" class="nav-tab" title="Einkaufsliste">
-            <i class="bi bi-cart3"></i>
-            <span>Einkauf</span>
-        </a>
-        <a href="wochenplan.html" class="nav-tab" title="Wochenplan">
-            <i class="bi bi-calendar-week"></i>
-            <span>Woche</span>
-        </a>
-        <a href="rezepte.html" class="nav-tab" title="Rezepte">
-            <i class="bi bi-book"></i>
-            <span>Rezepte</span>
-        </a>
+    <div class="navbar-left">
+        <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
         <a href="index.html" class="btn-nav btn-nav-icon" title="Zurück">

--- a/public/app.css
+++ b/public/app.css
@@ -45,7 +45,7 @@ body {
     padding: 0 0.75rem;
     height: 56px;
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-columns: 1fr auto;
     align-items: center;
     position: sticky;
     top: 0;
@@ -54,27 +54,10 @@ body {
 }
 .navbar-left { display: flex; align-items: center; }
 .navbar-right { display: flex; align-items: center; justify-content: flex-end; }
-.navbar-center {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.25rem;
-}
-.nav-tab {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.4rem 0.85rem;
-    border-radius: 8px;
-    color: rgba(255,255,255,0.6);
-    text-decoration: none;
-    font-size: 0.85rem;
-    font-weight: 600;
-    transition: background 0.15s, color 0.15s;
-    white-space: nowrap;
-}
-.nav-tab:hover { background: rgba(255,255,255,0.12); color: rgba(255,255,255,0.85); }
-.nav-tab.active { background: rgba(255,255,255,0.2); color: #fff; }
+/* Nav menu items in dropdown */
+.nav-menu-link.active { background: var(--green-50); color: var(--green-600); font-weight: 700; }
+.nav-menu-link.active i { color: var(--green-600); }
+.nav-menu-divider { height: 1px; background: var(--gray-200); margin: 0.25rem 0; }
 
 /* Nav Dropdown */
 .nav-dropdown { position: relative; }

--- a/public/app.js
+++ b/public/app.js
@@ -752,4 +752,4 @@ updateOnlineStatus();
 
 // -- Init --
 _onLogout = () => { items = []; };
-checkAuth(showApp);
+if (!_redirecting) checkAuth(showApp);

--- a/public/index.html
+++ b/public/index.html
@@ -27,24 +27,8 @@
 
 <!-- Navbar -->
 <nav class="navbar">
-    <div class="navbar-left"></div>
-    <div class="navbar-center">
-        <a href="index.html" class="nav-tab active" title="Einkaufsliste">
-            <i class="bi bi-cart3"></i>
-            <span>Einkauf</span>
-        </a>
-        <a href="wochenplan.html" class="nav-tab" title="Wochenplan">
-            <i class="bi bi-calendar-week"></i>
-            <span>Woche</span>
-        </a>
-        <a href="rezepte.html" class="nav-tab" title="Rezepte">
-            <i class="bi bi-book"></i>
-            <span>Rezepte</span>
-        </a>
-        <a href="tankrabatte.html" class="nav-tab" title="Aktionen">
-            <i class="bi bi-tag"></i>
-            <span>Aktionen</span>
-        </a>
+    <div class="navbar-left">
+        <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">
@@ -52,9 +36,14 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
-                <button onclick="openProfil();closeNavDropdown()" id="profilBtn" style="display:none">
+                <a href="index.html" class="nav-menu-link active"><i class="bi bi-cart3"></i> Einkauf</a>
+                <a href="wochenplan.html" class="nav-menu-link"><i class="bi bi-calendar-week"></i> Woche</a>
+                <a href="rezepte.html" class="nav-menu-link"><i class="bi bi-book"></i> Rezepte</a>
+                <a href="tankrabatte.html" class="nav-menu-link"><i class="bi bi-tag"></i> Aktionen</a>
+                <div class="nav-menu-divider"></div>
+                <a href="profil.html" id="profilBtn" style="display:none;text-decoration:none">
                     <i class="bi bi-person"></i> Profil
-                </button>
+                </a>
                 <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
                     <i class="bi bi-people"></i> Haushalt
                 </button>
@@ -252,68 +241,6 @@
             </div>
             <div id="rezeptResults" style="margin-top:1rem"></div>
             <div id="rezeptZutaten" style="margin-top:1rem"></div>
-        </div>
-    </div>
-</div>
-
-<!-- Modal: Profil -->
-<div class="modal-overlay" id="profilOverlay" onclick="if(event.target===this)closeProfil()">
-    <div class="modal" style="max-width:420px">
-        <div class="modal-header">
-            <h2><i class="bi bi-person"></i> Profil</h2>
-            <button class="modal-close" onclick="closeProfil()"><i class="bi bi-x-lg"></i></button>
-        </div>
-        <div class="modal-body">
-            <div style="margin-bottom:0.75rem">
-                <label>Benutzername</label>
-                <input type="text" id="profilUser" disabled style="background:var(--gray-100);color:var(--gray-500)">
-            </div>
-            <div style="margin-bottom:1rem">
-                <label for="profilEmail">E-Mail</label>
-                <input type="email" id="profilEmail" placeholder="name@beispiel.ch">
-            </div>
-            <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-bottom:1.25rem">
-                <button class="btn btn-secondary" onclick="closeProfil()">Abbrechen</button>
-                <button class="btn btn-primary" onclick="saveProfil()"><i class="bi bi-check-lg"></i> Speichern</button>
-            </div>
-            <hr style="border:none;border-top:1px solid var(--gray-200);margin-bottom:1rem">
-            <h3 style="font-size:0.95rem;margin-bottom:0.75rem"><i class="bi bi-key"></i> Passwort ändern</h3>
-            <div style="margin-bottom:0.75rem">
-                <label for="profilOldPass">Aktuelles Passwort</label>
-                <input type="password" id="profilOldPass" autocomplete="current-password" placeholder="Aktuelles Passwort">
-            </div>
-            <div style="margin-bottom:0.5rem">
-                <label for="profilNewPass">Neues Passwort</label>
-                <input type="password" id="profilNewPass" autocomplete="new-password" placeholder="Neues Passwort" oninput="checkProfilPwPolicy()">
-            </div>
-            <div id="profilPwPolicy" style="font-size:0.78rem;line-height:1.6;margin-bottom:0.5rem">
-                <div id="ppol-len"><i class="bi bi-x-circle"></i> Mindestens 8 Zeichen</div>
-                <div id="ppol-upper"><i class="bi bi-x-circle"></i> Mindestens 1 Grossbuchstabe</div>
-                <div id="ppol-lower"><i class="bi bi-x-circle"></i> Mindestens 1 Kleinbuchstabe</div>
-                <div id="ppol-special"><i class="bi bi-x-circle"></i> Mindestens 1 Sonderzeichen</div>
-            </div>
-            <div style="margin-bottom:0.75rem">
-                <label for="profilNewPassConfirm">Neues Passwort bestätigen</label>
-                <input type="password" id="profilNewPassConfirm" autocomplete="new-password" placeholder="Passwort wiederholen" oninput="checkProfilPwPolicy()">
-            </div>
-            <div id="ppol-match" style="font-size:0.78rem;display:none;margin-bottom:0.5rem"><i class="bi bi-x-circle"></i> Passwörter stimmen überein</div>
-            <div id="profilPwError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
-            <div id="profilPwSuccess" style="display:none;color:var(--green-600);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
-            <div style="display:flex;justify-content:flex-end">
-                <button class="btn btn-primary" onclick="changePassword()"><i class="bi bi-key"></i> Passwort ändern</button>
-            </div>
-          <!-- Biometrische Anmeldung -->
-          <hr style="margin:16px 0;">
-          <h3><i class="bi bi-fingerprint"></i> Biometrische Anmeldung</h3>
-          <div id="webauthnGeraeteSection" style="display:none;">
-            <div id="webauthnGeraeteListe"></div>
-            <button class="btn btn-secondary" style="width:100%;margin-top:8px;" onclick="webauthnNeuesGeraet()">
-              <i class="bi bi-plus-circle"></i> Neues Gerät hinzufügen
-            </button>
-          </div>
-          <div id="webauthnNichtVerfuegbar" style="display:none;color:var(--text-muted);">
-            <p>Biometrische Anmeldung wird von diesem Browser nicht unterstützt.</p>
-          </div>
         </div>
     </div>
 </div>

--- a/public/profil.html
+++ b/public/profil.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="theme-color" content="#2563eb">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="apple-mobile-web-app-title" content="Haushalt+">
+    <title>Profil — HaushaltPLUS</title>
+
+    <link rel="manifest" href="manifest.json">
+    <link rel="apple-touch-icon" href="icons/icon-192.svg">
+    <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
+    <link rel="stylesheet" href="app.css">
+</head>
+<body>
+
+<nav class="navbar">
+    <div class="navbar-left">
+        <span class="navbar-brand">HaushaltPLUS</span>
+    </div>
+    <div class="navbar-right">
+        <div class="nav-dropdown" id="navDropdown">
+            <button class="btn-nav btn-nav-icon" onclick="toggleNavDropdown(event)" title="Menü">
+                <i class="bi bi-three-dots-vertical"></i>
+            </button>
+            <div class="nav-dropdown-menu" id="navDropdownMenu">
+                <a href="index.html" class="nav-menu-link"><i class="bi bi-cart3"></i> Einkauf</a>
+                <a href="wochenplan.html" class="nav-menu-link"><i class="bi bi-calendar-week"></i> Woche</a>
+                <a href="rezepte.html" class="nav-menu-link"><i class="bi bi-book"></i> Rezepte</a>
+                <a href="tankrabatte.html" class="nav-menu-link"><i class="bi bi-tag"></i> Aktionen</a>
+                <div class="nav-menu-divider"></div>
+                <a href="profil.html" class="nav-menu-link active">
+                    <i class="bi bi-person"></i> Profil
+                </a>
+                <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
+                    <i class="bi bi-people"></i> Haushalt
+                </button>
+                <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
+                    <i class="bi bi-box-arrow-left"></i> Abmelden
+                </button>
+                <button onclick="openBugReport();closeNavDropdown()">
+                    <i class="bi bi-bug"></i> Bug melden
+                </button>
+                <a href="about.html" style="text-decoration:none">
+                    <i class="bi bi-info-circle"></i> Über
+                </a>
+            </div>
+        </div>
+    </div>
+</nav>
+
+<div id="appContent" class="app-content hidden">
+<div class="container" style="max-width:480px;margin:0 auto">
+
+    <!-- Profil -->
+    <div style="background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem;margin-bottom:1rem">
+        <h2 style="font-size:1.1rem;margin-bottom:1rem;display:flex;align-items:center;gap:0.4rem">
+            <i class="bi bi-person" style="color:var(--green-600)"></i> Profil
+        </h2>
+        <div style="margin-bottom:0.75rem">
+            <label>Benutzername</label>
+            <input type="text" id="profilUser" disabled style="background:var(--gray-100);color:var(--gray-500)">
+        </div>
+        <div style="margin-bottom:1rem">
+            <label for="profilEmail">E-Mail</label>
+            <input type="email" id="profilEmail" placeholder="name@beispiel.ch">
+        </div>
+        <div style="display:flex;justify-content:flex-end">
+            <button class="btn btn-primary" onclick="saveProfil()"><i class="bi bi-check-lg"></i> Speichern</button>
+        </div>
+    </div>
+
+    <!-- Passwort ändern -->
+    <div style="background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem;margin-bottom:1rem">
+        <h2 style="font-size:1.1rem;margin-bottom:1rem;display:flex;align-items:center;gap:0.4rem">
+            <i class="bi bi-key" style="color:var(--green-600)"></i> Passwort ändern
+        </h2>
+        <div style="margin-bottom:0.75rem">
+            <label for="profilOldPass">Aktuelles Passwort</label>
+            <input type="password" id="profilOldPass" autocomplete="current-password" placeholder="Aktuelles Passwort">
+        </div>
+        <div style="margin-bottom:0.5rem">
+            <label for="profilNewPass">Neues Passwort</label>
+            <input type="password" id="profilNewPass" autocomplete="new-password" placeholder="Neues Passwort" oninput="checkProfilPwPolicy()">
+        </div>
+        <div id="profilPwPolicy" style="font-size:0.78rem;line-height:1.6;margin-bottom:0.5rem">
+            <div id="ppol-len"><i class="bi bi-x-circle"></i> Mindestens 8 Zeichen</div>
+            <div id="ppol-upper"><i class="bi bi-x-circle"></i> Mindestens 1 Grossbuchstabe</div>
+            <div id="ppol-lower"><i class="bi bi-x-circle"></i> Mindestens 1 Kleinbuchstabe</div>
+            <div id="ppol-special"><i class="bi bi-x-circle"></i> Mindestens 1 Sonderzeichen</div>
+        </div>
+        <div style="margin-bottom:0.75rem">
+            <label for="profilNewPassConfirm">Neues Passwort bestätigen</label>
+            <input type="password" id="profilNewPassConfirm" autocomplete="new-password" placeholder="Passwort wiederholen" oninput="checkProfilPwPolicy()">
+        </div>
+        <div id="ppol-match" style="font-size:0.78rem;display:none;margin-bottom:0.5rem"><i class="bi bi-x-circle"></i> Passwörter stimmen überein</div>
+        <div id="profilPwError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
+        <div id="profilPwSuccess" style="display:none;color:var(--green-600);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
+        <div style="display:flex;justify-content:flex-end">
+            <button class="btn btn-primary" onclick="changePassword()"><i class="bi bi-key"></i> Passwort ändern</button>
+        </div>
+    </div>
+
+    <!-- Biometrische Anmeldung -->
+    <div style="background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem;margin-bottom:1rem">
+        <h2 style="font-size:1.1rem;margin-bottom:1rem;display:flex;align-items:center;gap:0.4rem">
+            <i class="bi bi-fingerprint" style="color:var(--green-600)"></i> Biometrische Anmeldung
+        </h2>
+        <div id="webauthnGeraeteSection" style="display:none;">
+            <div id="webauthnGeraeteListe"></div>
+            <button class="btn btn-secondary" style="width:100%;margin-top:8px;" onclick="webauthnNeuesGeraet()">
+                <i class="bi bi-plus-circle"></i> Neues Gerät hinzufügen
+            </button>
+        </div>
+        <div id="webauthnNichtVerfuegbar" style="display:none;color:var(--gray-500);">
+            <p>Biometrische Anmeldung wird von diesem Browser nicht unterstützt.</p>
+        </div>
+    </div>
+
+</div>
+</div>
+
+<!-- Login Screen -->
+<div id="loginScreen" class="login-screen">
+    <div class="login-card">
+        <div class="login-header">
+            <i class="bi bi-person" style="font-size:2.5rem;color:var(--green-600)"></i>
+            <h1 style="font-size:1.5rem;margin-top:0.5rem">Profil</h1>
+            <p style="color:var(--gray-500);font-size:0.85rem;margin-top:0.25rem">Anmelden</p>
+        </div>
+        <form onsubmit="submitAuth(event)">
+            <div style="display:flex;flex-direction:column;gap:0.75rem">
+                <div>
+                    <label for="authUser">Benutzername</label>
+                    <input type="text" id="authUser" required autocomplete="username" placeholder="Benutzername">
+                </div>
+                <div>
+                    <label for="authPass">Passwort</label>
+                    <input type="password" id="authPass" required autocomplete="current-password" placeholder="Passwort">
+                </div>
+                <div id="authError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500"></div>
+                <div id="authSuccess" style="display:none;color:var(--green-600);font-size:0.8rem;font-weight:500"></div>
+                <button type="submit" class="btn btn-primary" style="width:100%;padding:0.7rem;font-size:0.95rem">
+                    <i class="bi bi-box-arrow-in-right"></i> Anmelden
+                </button>
+                <a href="register.html" class="btn btn-secondary" style="width:100%;padding:0.7rem;font-size:0.95rem;text-decoration:none;text-align:center">
+                    <i class="bi bi-person-plus"></i> Registrieren
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<!-- Toasts -->
+<div class="toast-container" id="toasts"></div>
+
+<script src="lib/simplewebauthn-browser.min.js"></script>
+<script src="webauthn.js"></script>
+<script src="shared.js"></script>
+<script src="bugreport.js"></script>
+<script src="profil.js"></script>
+
+</body>
+</html>

--- a/public/profil.js
+++ b/public/profil.js
@@ -1,0 +1,8 @@
+function showApp() {
+    showAppBase();
+    document.getElementById('profilUser').value = currentUser?.benutzername || '';
+    document.getElementById('profilEmail').value = currentUser?.email || '';
+    if (typeof WebAuthnClient !== 'undefined') webauthnLadeGeraeteProfil();
+}
+
+if (!_redirecting) checkAuth(showApp);

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -75,24 +75,8 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left"></div>
-    <div class="navbar-center">
-        <a href="index.html" class="nav-tab" title="Einkaufsliste">
-            <i class="bi bi-cart3"></i>
-            <span>Einkauf</span>
-        </a>
-        <a href="wochenplan.html" class="nav-tab" title="Wochenplan">
-            <i class="bi bi-calendar-week"></i>
-            <span>Woche</span>
-        </a>
-        <a href="rezepte.html" class="nav-tab active" title="Rezepte">
-            <i class="bi bi-book"></i>
-            <span>Rezepte</span>
-        </a>
-        <a href="tankrabatte.html" class="nav-tab" title="Aktionen">
-            <i class="bi bi-tag"></i>
-            <span>Aktionen</span>
-        </a>
+    <div class="navbar-left">
+        <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">
@@ -100,14 +84,19 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
+                <a href="index.html" class="nav-menu-link"><i class="bi bi-cart3"></i> Einkauf</a>
+                <a href="wochenplan.html" class="nav-menu-link"><i class="bi bi-calendar-week"></i> Woche</a>
+                <a href="rezepte.html" class="nav-menu-link active"><i class="bi bi-book"></i> Rezepte</a>
+                <a href="tankrabatte.html" class="nav-menu-link"><i class="bi bi-tag"></i> Aktionen</a>
+                <div class="nav-menu-divider"></div>
                 <button onclick="openGerichteModal();closeNavDropdown()">
                     <i class="bi bi-book"></i> Eigene Gerichte
                 </button>
+                <a href="profil.html" id="profilBtn" style="display:none;text-decoration:none">
+                    <i class="bi bi-person"></i> Profil
+                </a>
                 <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
                     <i class="bi bi-people"></i> Haushalt
-                </button>
-                <button onclick="openProfil();closeNavDropdown()" id="profilBtn" style="display:none">
-                    <i class="bi bi-person"></i> Profil
                 </button>
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden
@@ -223,30 +212,6 @@
             <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem">
                 <button class="btn btn-secondary" onclick="closeGerichtEdit()">Abbrechen</button>
                 <button class="btn btn-primary" onclick="saveGericht()"><i class="bi bi-check-lg"></i> Speichern</button>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!-- Modal: Profil -->
-<div class="modal-overlay" id="profilOverlay" onclick="if(event.target===this)closeProfil()">
-    <div class="modal" style="max-width:420px">
-        <div class="modal-header">
-            <h2><i class="bi bi-person"></i> Profil</h2>
-            <button class="modal-close" onclick="closeProfil()"><i class="bi bi-x-lg"></i></button>
-        </div>
-        <div class="modal-body">
-            <div style="margin-bottom:0.75rem">
-                <label>Benutzername</label>
-                <input type="text" id="profilUser" disabled style="background:var(--gray-100);color:var(--gray-500)">
-            </div>
-            <div style="margin-bottom:1rem">
-                <label for="profilEmail">E-Mail</label>
-                <input type="email" id="profilEmail" placeholder="name@beispiel.ch">
-            </div>
-            <div style="display:flex;gap:0.5rem;justify-content:flex-end">
-                <button class="btn btn-secondary" onclick="closeProfil()">Abbrechen</button>
-                <button class="btn btn-primary" onclick="saveProfil()"><i class="bi bi-check-lg"></i> Speichern</button>
             </div>
         </div>
     </div>

--- a/public/rezepte.js
+++ b/public/rezepte.js
@@ -375,8 +375,8 @@ async function deleteGericht(id) {
 
 // -- Keyboard --
 document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') { closeAddToPlan(); closeGerichteModal(); closeGerichtEdit(); closeProfil(); closeHaushalt(); }
+    if (e.key === 'Escape') { closeAddToPlan(); closeGerichteModal(); closeGerichtEdit(); closeHaushalt(); }
 });
 
 // -- Init --
-checkAuth(showApp);
+if (!_redirecting) checkAuth(showApp);

--- a/public/shared.js
+++ b/public/shared.js
@@ -1,5 +1,21 @@
 // -- Shared utilities across all pages --
 
+// Letzte besuchte Seite merken und Redirect
+let _redirecting = false;
+(function() {
+    const page = location.pathname.split('/').pop() || 'index.html';
+    const trackablePages = ['index.html', 'wochenplan.html', 'rezepte.html', 'tankrabatte.html'];
+    if (trackablePages.includes(page)) {
+        const lastPage = localStorage.getItem('lastVisitedPage');
+        if (lastPage && lastPage !== page && trackablePages.includes(lastPage)) {
+            _redirecting = true;
+            location.replace(lastPage);
+            return;
+        }
+        localStorage.setItem('lastVisitedPage', page);
+    }
+})();
+
 let currentUser = null;
 
 function esc(s) {
@@ -92,25 +108,6 @@ function toast(msg, isError) {
 }
 
 // -- Profil --
-function openProfil() {
-    document.getElementById('profilUser').value = currentUser?.benutzername || '';
-    document.getElementById('profilEmail').value = currentUser?.email || '';
-    document.getElementById('profilOverlay').classList.add('active');
-    if (typeof WebAuthnClient !== 'undefined') webauthnLadeGeraeteProfil();
-}
-
-function closeProfil() {
-    document.getElementById('profilOverlay').classList.remove('active');
-    // Reset password fields
-    const ids = ['profilOldPass', 'profilNewPass', 'profilNewPassConfirm'];
-    ids.forEach(id => { const el = document.getElementById(id); if (el) el.value = ''; });
-    const errEl = document.getElementById('profilPwError');
-    const successEl = document.getElementById('profilPwSuccess');
-    if (errEl) errEl.style.display = 'none';
-    if (successEl) successEl.style.display = 'none';
-    resetProfilPwPolicy();
-}
-
 function resetProfilPwPolicy() {
     ['ppol-len','ppol-upper','ppol-lower','ppol-special'].forEach(id => {
         const el = document.getElementById(id);
@@ -190,7 +187,6 @@ async function saveProfil() {
     if (res.ok) {
         currentUser.email = email;
         toast('Profil gespeichert');
-        closeProfil();
     }
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'einkaufsliste-v10';
+const CACHE_NAME = 'einkaufsliste-v11';
 const ASSETS = [
     './',
     './index.html',
@@ -8,6 +8,8 @@ const ASSETS = [
     './rezepte.html',
     './wochenplan.html',
     './tankrabatte.html',
+    './profil.html',
+    './profil.js',
     './app.css',
     './app.js',
     './shared.js',

--- a/public/tankrabatte.html
+++ b/public/tankrabatte.html
@@ -15,24 +15,8 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left"></div>
-    <div class="navbar-center">
-        <a href="index.html" class="nav-tab" title="Einkaufsliste">
-            <i class="bi bi-cart3"></i>
-            <span>Einkauf</span>
-        </a>
-        <a href="wochenplan.html" class="nav-tab" title="Wochenplan">
-            <i class="bi bi-calendar-week"></i>
-            <span>Woche</span>
-        </a>
-        <a href="rezepte.html" class="nav-tab" title="Rezepte">
-            <i class="bi bi-book"></i>
-            <span>Rezepte</span>
-        </a>
-        <a href="tankrabatte.html" class="nav-tab active" title="Aktionen">
-            <i class="bi bi-tag"></i>
-            <span>Aktionen</span>
-        </a>
+    <div class="navbar-left">
+        <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">
@@ -40,11 +24,16 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
+                <a href="index.html" class="nav-menu-link"><i class="bi bi-cart3"></i> Einkauf</a>
+                <a href="wochenplan.html" class="nav-menu-link"><i class="bi bi-calendar-week"></i> Woche</a>
+                <a href="rezepte.html" class="nav-menu-link"><i class="bi bi-book"></i> Rezepte</a>
+                <a href="tankrabatte.html" class="nav-menu-link active"><i class="bi bi-tag"></i> Aktionen</a>
+                <div class="nav-menu-divider"></div>
+                <a href="profil.html" id="profilBtn" style="display:none;text-decoration:none">
+                    <i class="bi bi-person"></i> Profil
+                </a>
                 <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
                     <i class="bi bi-people"></i> Haushalt
-                </button>
-                <button onclick="openProfil();closeNavDropdown()" id="profilBtn" style="display:none">
-                    <i class="bi bi-person"></i> Profil
                 </button>
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden
@@ -181,30 +170,6 @@
                 </a>
             </div>
         </form>
-    </div>
-</div>
-
-<!-- Modal: Profil -->
-<div class="modal-overlay" id="profilOverlay" onclick="if(event.target===this)closeProfil()">
-    <div class="modal" style="max-width:420px">
-        <div class="modal-header">
-            <h2><i class="bi bi-person"></i> Profil</h2>
-            <button class="modal-close" onclick="closeProfil()"><i class="bi bi-x-lg"></i></button>
-        </div>
-        <div class="modal-body">
-            <div style="margin-bottom:0.75rem">
-                <label>Benutzername</label>
-                <input type="text" id="profilUser" disabled style="background:var(--gray-100);color:var(--gray-500)">
-            </div>
-            <div style="margin-bottom:1rem">
-                <label for="profilEmail">E-Mail</label>
-                <input type="email" id="profilEmail" placeholder="name@beispiel.ch">
-            </div>
-            <div style="display:flex;gap:0.5rem;justify-content:flex-end">
-                <button class="btn btn-secondary" onclick="closeProfil()">Abbrechen</button>
-                <button class="btn btn-primary" onclick="saveProfil()"><i class="bi bi-check-lg"></i> Speichern</button>
-            </div>
-        </div>
     </div>
 </div>
 

--- a/public/tankrabatte.js
+++ b/public/tankrabatte.js
@@ -220,4 +220,4 @@ function renderAnbieter(key, gutscheine) {
     }).join('');
 }
 
-checkAuth(showApp);
+if (!_redirecting) checkAuth(showApp);

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -15,24 +15,8 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left"></div>
-    <div class="navbar-center">
-        <a href="index.html" class="nav-tab" title="Einkaufsliste">
-            <i class="bi bi-cart3"></i>
-            <span>Einkauf</span>
-        </a>
-        <a href="wochenplan.html" class="nav-tab active" title="Wochenplan">
-            <i class="bi bi-calendar-week"></i>
-            <span>Woche</span>
-        </a>
-        <a href="rezepte.html" class="nav-tab" title="Rezepte">
-            <i class="bi bi-book"></i>
-            <span>Rezepte</span>
-        </a>
-        <a href="tankrabatte.html" class="nav-tab" title="Aktionen">
-            <i class="bi bi-tag"></i>
-            <span>Aktionen</span>
-        </a>
+    <div class="navbar-left">
+        <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">
@@ -40,14 +24,19 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
+                <a href="index.html" class="nav-menu-link"><i class="bi bi-cart3"></i> Einkauf</a>
+                <a href="wochenplan.html" class="nav-menu-link active"><i class="bi bi-calendar-week"></i> Woche</a>
+                <a href="rezepte.html" class="nav-menu-link"><i class="bi bi-book"></i> Rezepte</a>
+                <a href="tankrabatte.html" class="nav-menu-link"><i class="bi bi-tag"></i> Aktionen</a>
+                <div class="nav-menu-divider"></div>
                 <button onclick="openGerichteModal();closeNavDropdown()">
                     <i class="bi bi-book"></i> Eigene Gerichte
                 </button>
+                <a href="profil.html" id="profilBtn" style="display:none;text-decoration:none">
+                    <i class="bi bi-person"></i> Profil
+                </a>
                 <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
                     <i class="bi bi-people"></i> Haushalt
-                </button>
-                <button onclick="openProfil();closeNavDropdown()" id="profilBtn" style="display:none">
-                    <i class="bi bi-person"></i> Profil
                 </button>
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden
@@ -117,30 +106,6 @@
             <button class="modal-close" onclick="closeDishSearch()"><i class="bi bi-x-lg"></i></button>
         </div>
         <div class="modal-body" id="dishSearchBody">
-        </div>
-    </div>
-</div>
-
-<!-- Modal: Profil -->
-<div class="modal-overlay" id="profilOverlay" onclick="if(event.target===this)closeProfil()">
-    <div class="modal" style="max-width:420px">
-        <div class="modal-header">
-            <h2><i class="bi bi-person"></i> Profil</h2>
-            <button class="modal-close" onclick="closeProfil()"><i class="bi bi-x-lg"></i></button>
-        </div>
-        <div class="modal-body">
-            <div style="margin-bottom:0.75rem">
-                <label>Benutzername</label>
-                <input type="text" id="profilUser" disabled style="background:var(--gray-100);color:var(--gray-500)">
-            </div>
-            <div style="margin-bottom:1rem">
-                <label for="profilEmail">E-Mail</label>
-                <input type="email" id="profilEmail" placeholder="name@beispiel.ch">
-            </div>
-            <div style="display:flex;gap:0.5rem;justify-content:flex-end">
-                <button class="btn btn-secondary" onclick="closeProfil()">Abbrechen</button>
-                <button class="btn btn-primary" onclick="saveProfil()"><i class="bi bi-check-lg"></i> Speichern</button>
-            </div>
         </div>
     </div>
 </div>

--- a/public/wochenplan.js
+++ b/public/wochenplan.js
@@ -688,4 +688,4 @@ document.addEventListener('keydown', e => {
 });
 
 // -- Init --
-checkAuth(showApp);
+if (!_redirecting) checkAuth(showApp);


### PR DESCRIPTION
## Summary
- **Navigation ins Dreipunkt-Menü verschoben**: Alle 4 Nav-Tabs (Einkauf, Woche, Rezepte, Aktionen) sind jetzt im Dropdown-Menü statt in der Navbar-Mitte. Navbar zeigt nur noch "HaushaltPLUS" und das Menü-Icon.
- **Neue Profil-Seite** (`profil.html`): Ersetzt das bisherige Profil-Modal auf allen Seiten. Enthält E-Mail-Änderung, Passwort-Änderung und WebAuthn-Geräteverwaltung als Card-Layout.
- **Letzte besuchte Seite merken**: Via `localStorage` wird die zuletzt besuchte Hauptseite gespeichert und beim App-Start automatisch dorthin weitergeleitet.

## Changes
- 12 geänderte Dateien, 2 neue Dateien (`profil.html`, `profil.js`)
- Profil-Modal aus allen 4 Hauptseiten entfernt
- Service Worker Cache auf v11 aktualisiert

## Test plan
- [ ] App starten, einloggen — Navbar zeigt "HaushaltPLUS" links und Dreipunkt-Menü rechts
- [ ] Dreipunkt-Menü öffnen — alle 4 Navigationslinks sichtbar, aktuelle Seite hervorgehoben
- [ ] Navigation zwischen Seiten testen — aktiver Link wechselt korrekt
- [ ] Profil im Menü klicken — neue Profil-Seite öffnet sich
- [ ] E-Mail ändern, Passwort ändern, WebAuthn-Geräte verwalten auf Profil-Seite testen
- [ ] Browser schliessen und wieder öffnen — App öffnet die zuletzt besuchte Seite
- [ ] PWA: App vom Homescreen öffnen — Redirect auf letzte Seite funktioniert

🤖 Generated with [Claude Code](https://claude.com/claude-code)