### PR TITLE
feat: Linke Sidebar-Navigation mit Mobile-Collapse

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -54,11 +54,6 @@ body {
 }
 .navbar-left { display: flex; align-items: center; }
 .navbar-right { display: flex; align-items: center; justify-content: flex-end; }
-/* Nav menu items in dropdown */
-.nav-menu-link.active { background: var(--green-50); color: var(--green-600); font-weight: 700; }
-.nav-menu-link.active i { color: var(--green-600); }
-.nav-menu-divider { height: 1px; background: var(--gray-200); margin: 0.25rem 0; }
-
 /* Nav Dropdown */
 .nav-dropdown { position: relative; }
 .nav-dropdown-menu {
@@ -121,6 +116,59 @@ body {
 }
 .btn-nav:hover { background: rgba(255,255,255,0.2); }
 .btn-nav-icon { padding: 0.5rem; width: 40px; height: 40px; justify-content: center; font-size: 1.1rem; }
+
+/* -- Sidebar -- */
+.sidebar {
+    position: fixed;
+    top: 56px;
+    left: 0;
+    bottom: 0;
+    width: 200px;
+    background: var(--surface);
+    border-right: 1px solid var(--gray-200);
+    z-index: 90;
+    display: flex;
+    flex-direction: column;
+    transition: width 0.2s ease;
+    overflow: hidden;
+}
+.sidebar.hidden { display: none; }
+.sidebar-toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 0.6rem;
+    border: none;
+    background: none;
+    color: var(--gray-500);
+    font-size: 1.2rem;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.sidebar-toggle:hover { background: var(--gray-100); }
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    padding: 0.5rem 0;
+    gap: 0.15rem;
+}
+.sidebar-link {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.7rem 1rem;
+    color: var(--gray-600);
+    text-decoration: none;
+    font-size: 0.85rem;
+    font-weight: 500;
+    transition: background 0.15s, color 0.15s;
+    white-space: nowrap;
+}
+.sidebar-link:hover { background: var(--gray-100); color: var(--gray-800); }
+.sidebar-link.active { background: var(--green-50); color: var(--green-600); font-weight: 700; }
+.sidebar-link i { font-size: 1.1rem; width: 1.4rem; text-align: center; flex-shrink: 0; }
+.sidebar-link.active i { color: var(--green-600); }
 
 /* -- Install banner -- */
 .install-banner {
@@ -697,6 +745,7 @@ input:focus, select:focus {
     .modal-overlay { align-items: center; padding: 1rem; }
     .modal { border-radius: var(--radius); }
     .navbar-brand .short-label { display: none; }
+    .app-content { margin-left: 200px; }
 }
 
 @media (max-width: 768px) {
@@ -710,6 +759,16 @@ input:focus, select:focus {
     .tile-grid { grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 0.5rem; }
     .gekauft-grid.open { grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 0.5rem; }
     .tile { padding: 0.6rem 0.75rem; }
+
+    /* Sidebar: collapsed on mobile */
+    .sidebar { width: 56px; }
+    .sidebar-link span { display: none; }
+    .sidebar-link { justify-content: center; padding: 0.7rem 0; }
+    .sidebar-toggle { display: flex; }
+    .sidebar.expanded { width: 200px; box-shadow: var(--shadow-lg); }
+    .sidebar.expanded .sidebar-link span { display: inline; }
+    .sidebar.expanded .sidebar-link { justify-content: flex-start; padding: 0.7rem 1rem; }
+    .app-content { margin-left: 56px; }
 
     /* Larger touch targets on mobile */
     input, select { padding: 0.7rem 0.75rem; font-size: 1rem; }
@@ -951,6 +1010,7 @@ input:focus, select:focus {
 /* Safe area for notch devices */
 @supports (padding: env(safe-area-inset-top)) {
     .navbar { padding-top: env(safe-area-inset-top); height: calc(56px + env(safe-area-inset-top)); }
+    .sidebar { top: calc(56px + env(safe-area-inset-top)); }
     .container {
         padding-left: max(0.5rem, env(safe-area-inset-left));
         padding-right: max(0.5rem, env(safe-area-inset-right));

--- a/public/index.html
+++ b/public/index.html
@@ -36,14 +36,6 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
-                <a href="index.html" class="nav-menu-link active"><i class="bi bi-cart3"></i> Einkauf</a>
-                <a href="wochenplan.html" class="nav-menu-link"><i class="bi bi-calendar-week"></i> Woche</a>
-                <a href="rezepte.html" class="nav-menu-link"><i class="bi bi-book"></i> Rezepte</a>
-                <a href="tankrabatte.html" class="nav-menu-link"><i class="bi bi-tag"></i> Aktionen</a>
-                <div class="nav-menu-divider"></div>
-                <a href="profil.html" id="profilBtn" style="display:none;text-decoration:none">
-                    <i class="bi bi-person"></i> Profil
-                </a>
                 <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
                     <i class="bi bi-people"></i> Haushalt
                 </button>
@@ -60,6 +52,20 @@
         </div>
     </div>
 </nav>
+
+<!-- Sidebar -->
+<aside class="sidebar hidden" id="sidebar">
+    <button class="sidebar-toggle" onclick="toggleSidebar()" title="Menü ein-/ausblenden">
+        <i class="bi bi-list"></i>
+    </button>
+    <nav class="sidebar-nav">
+        <a href="index.html" class="sidebar-link active"><i class="bi bi-cart3"></i> <span>Einkauf</span></a>
+        <a href="wochenplan.html" class="sidebar-link"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
+        <a href="rezepte.html" class="sidebar-link"><i class="bi bi-book"></i> <span>Rezepte</span></a>
+        <a href="tankrabatte.html" class="sidebar-link"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="profil.html" class="sidebar-link"><i class="bi bi-person"></i> <span>Profil</span></a>
+    </nav>
+</aside>
 
 <!-- Install Banner -->
 <div class="install-banner" id="installBanner">

--- a/public/profil.html
+++ b/public/profil.html
@@ -29,14 +29,6 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
-                <a href="index.html" class="nav-menu-link"><i class="bi bi-cart3"></i> Einkauf</a>
-                <a href="wochenplan.html" class="nav-menu-link"><i class="bi bi-calendar-week"></i> Woche</a>
-                <a href="rezepte.html" class="nav-menu-link"><i class="bi bi-book"></i> Rezepte</a>
-                <a href="tankrabatte.html" class="nav-menu-link"><i class="bi bi-tag"></i> Aktionen</a>
-                <div class="nav-menu-divider"></div>
-                <a href="profil.html" class="nav-menu-link active">
-                    <i class="bi bi-person"></i> Profil
-                </a>
                 <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
                     <i class="bi bi-people"></i> Haushalt
                 </button>
@@ -53,6 +45,19 @@
         </div>
     </div>
 </nav>
+
+<aside class="sidebar hidden" id="sidebar">
+    <button class="sidebar-toggle" onclick="toggleSidebar()" title="Menü ein-/ausblenden">
+        <i class="bi bi-list"></i>
+    </button>
+    <nav class="sidebar-nav">
+        <a href="index.html" class="sidebar-link"><i class="bi bi-cart3"></i> <span>Einkauf</span></a>
+        <a href="wochenplan.html" class="sidebar-link"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
+        <a href="rezepte.html" class="sidebar-link"><i class="bi bi-book"></i> <span>Rezepte</span></a>
+        <a href="tankrabatte.html" class="sidebar-link"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="profil.html" class="sidebar-link active"><i class="bi bi-person"></i> <span>Profil</span></a>
+    </nav>
+</aside>
 
 <div id="appContent" class="app-content hidden">
 <div class="container" style="max-width:480px;margin:0 auto">

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -84,17 +84,9 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
-                <a href="index.html" class="nav-menu-link"><i class="bi bi-cart3"></i> Einkauf</a>
-                <a href="wochenplan.html" class="nav-menu-link"><i class="bi bi-calendar-week"></i> Woche</a>
-                <a href="rezepte.html" class="nav-menu-link active"><i class="bi bi-book"></i> Rezepte</a>
-                <a href="tankrabatte.html" class="nav-menu-link"><i class="bi bi-tag"></i> Aktionen</a>
-                <div class="nav-menu-divider"></div>
                 <button onclick="openGerichteModal();closeNavDropdown()">
                     <i class="bi bi-book"></i> Eigene Gerichte
                 </button>
-                <a href="profil.html" id="profilBtn" style="display:none;text-decoration:none">
-                    <i class="bi bi-person"></i> Profil
-                </a>
                 <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
                     <i class="bi bi-people"></i> Haushalt
                 </button>
@@ -111,6 +103,19 @@
         </div>
     </div>
 </nav>
+
+<aside class="sidebar hidden" id="sidebar">
+    <button class="sidebar-toggle" onclick="toggleSidebar()" title="Menü ein-/ausblenden">
+        <i class="bi bi-list"></i>
+    </button>
+    <nav class="sidebar-nav">
+        <a href="index.html" class="sidebar-link"><i class="bi bi-cart3"></i> <span>Einkauf</span></a>
+        <a href="wochenplan.html" class="sidebar-link"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
+        <a href="rezepte.html" class="sidebar-link active"><i class="bi bi-book"></i> <span>Rezepte</span></a>
+        <a href="tankrabatte.html" class="sidebar-link"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="profil.html" class="sidebar-link"><i class="bi bi-person"></i> <span>Profil</span></a>
+    </nav>
+</aside>
 
 <div id="appContent" class="app-content hidden">
 <div class="container">

--- a/public/shared.js
+++ b/public/shared.js
@@ -34,17 +34,19 @@ async function checkAuth(onSuccess) {
 function showLogin() {
     document.getElementById('loginScreen').classList.remove('hidden');
     document.getElementById('appContent').classList.add('hidden');
+    const sidebar = document.getElementById('sidebar');
+    if (sidebar) sidebar.classList.add('hidden');
     if (typeof WebAuthnClient !== 'undefined') initWebauthnLogin();
 }
 
 function showAppBase() {
     document.getElementById('loginScreen').classList.add('hidden');
     document.getElementById('appContent').classList.remove('hidden');
+    const sidebar = document.getElementById('sidebar');
+    if (sidebar) sidebar.classList.remove('hidden');
     const logoutBtn = document.getElementById('logoutBtn');
-    const profilBtn = document.getElementById('profilBtn');
     const haushaltBtn = document.getElementById('haushaltBtn');
     if (logoutBtn) logoutBtn.style.display = '';
-    if (profilBtn) profilBtn.style.display = '';
     if (haushaltBtn) haushaltBtn.style.display = '';
     ensureHaushaltModal();
 }
@@ -364,7 +366,19 @@ function closeNavDropdown() {
     document.getElementById('navDropdownMenu').classList.remove('open');
 }
 
-document.addEventListener('click', () => closeNavDropdown());
+document.addEventListener('click', (e) => {
+    closeNavDropdown();
+    // Close expanded sidebar on click outside
+    const sidebar = document.getElementById('sidebar');
+    if (sidebar && sidebar.classList.contains('expanded') && !sidebar.contains(e.target)) {
+        sidebar.classList.remove('expanded');
+    }
+});
+
+// -- Sidebar Toggle --
+function toggleSidebar() {
+    document.getElementById('sidebar').classList.toggle('expanded');
+}
 
 // -- Password toggle --
 function initPasswordToggles() {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'einkaufsliste-v12';
+const CACHE_NAME = 'einkaufsliste-v13';
 const ASSETS = [
     './',
     './index.html',

--- a/public/tankrabatte.html
+++ b/public/tankrabatte.html
@@ -24,14 +24,6 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
-                <a href="index.html" class="nav-menu-link"><i class="bi bi-cart3"></i> Einkauf</a>
-                <a href="wochenplan.html" class="nav-menu-link"><i class="bi bi-calendar-week"></i> Woche</a>
-                <a href="rezepte.html" class="nav-menu-link"><i class="bi bi-book"></i> Rezepte</a>
-                <a href="tankrabatte.html" class="nav-menu-link active"><i class="bi bi-tag"></i> Aktionen</a>
-                <div class="nav-menu-divider"></div>
-                <a href="profil.html" id="profilBtn" style="display:none;text-decoration:none">
-                    <i class="bi bi-person"></i> Profil
-                </a>
                 <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
                     <i class="bi bi-people"></i> Haushalt
                 </button>
@@ -48,6 +40,19 @@
         </div>
     </div>
 </nav>
+
+<aside class="sidebar hidden" id="sidebar">
+    <button class="sidebar-toggle" onclick="toggleSidebar()" title="Menü ein-/ausblenden">
+        <i class="bi bi-list"></i>
+    </button>
+    <nav class="sidebar-nav">
+        <a href="index.html" class="sidebar-link"><i class="bi bi-cart3"></i> <span>Einkauf</span></a>
+        <a href="wochenplan.html" class="sidebar-link"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
+        <a href="rezepte.html" class="sidebar-link"><i class="bi bi-book"></i> <span>Rezepte</span></a>
+        <a href="tankrabatte.html" class="sidebar-link active"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="profil.html" class="sidebar-link"><i class="bi bi-person"></i> <span>Profil</span></a>
+    </nav>
+</aside>
 
 <div id="appContent" class="app-content hidden">
 <div class="container">

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -24,17 +24,9 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
-                <a href="index.html" class="nav-menu-link"><i class="bi bi-cart3"></i> Einkauf</a>
-                <a href="wochenplan.html" class="nav-menu-link active"><i class="bi bi-calendar-week"></i> Woche</a>
-                <a href="rezepte.html" class="nav-menu-link"><i class="bi bi-book"></i> Rezepte</a>
-                <a href="tankrabatte.html" class="nav-menu-link"><i class="bi bi-tag"></i> Aktionen</a>
-                <div class="nav-menu-divider"></div>
                 <button onclick="openGerichteModal();closeNavDropdown()">
                     <i class="bi bi-book"></i> Eigene Gerichte
                 </button>
-                <a href="profil.html" id="profilBtn" style="display:none;text-decoration:none">
-                    <i class="bi bi-person"></i> Profil
-                </a>
                 <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
                     <i class="bi bi-people"></i> Haushalt
                 </button>
@@ -51,6 +43,19 @@
         </div>
     </div>
 </nav>
+
+<aside class="sidebar hidden" id="sidebar">
+    <button class="sidebar-toggle" onclick="toggleSidebar()" title="Menü ein-/ausblenden">
+        <i class="bi bi-list"></i>
+    </button>
+    <nav class="sidebar-nav">
+        <a href="index.html" class="sidebar-link"><i class="bi bi-cart3"></i> <span>Einkauf</span></a>
+        <a href="wochenplan.html" class="sidebar-link active"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
+        <a href="rezepte.html" class="sidebar-link"><i class="bi bi-book"></i> <span>Rezepte</span></a>
+        <a href="tankrabatte.html" class="sidebar-link"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="profil.html" class="sidebar-link"><i class="bi bi-person"></i> <span>Profil</span></a>
+    </nav>
+</aside>
 
 <div id="appContent" class="app-content hidden">
 <div class="container">


### PR DESCRIPTION
## Summary
- **Linke Sidebar-Navigation**: Alle Nav-Links als fixierte Sidebar links
- **Desktop**: 200px breit mit Icons + Text, immer sichtbar
- **Mobile**: 56px (nur Icons), Toggle-Button zum Aufklappen
- **Dreipunkt-Menü** nur noch sekundäre Aktionen

## Test plan
- [ ] Desktop: Sidebar links mit Icons + Text
- [ ] Mobile: Nur Icons, Toggle klappt Text ein/aus
- [ ] Aktive Seite hervorgehoben
- [ ] Login-Screen: Sidebar nicht sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)