### PR TITLE
feat: Haushalt auf Profil-Seite, Passwort einklappbar, Titel zentriert

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -135,7 +135,8 @@
 
 <!-- Navbar -->
 <nav class="navbar">
-    <div class="navbar-left">
+    <div class="navbar-left"></div>
+    <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">

--- a/public/app.css
+++ b/public/app.css
@@ -45,7 +45,7 @@ body {
     padding: 0 0.75rem;
     height: 56px;
     display: grid;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: auto 1fr auto;
     align-items: center;
     position: sticky;
     top: 0;
@@ -53,6 +53,7 @@ body {
     box-shadow: 0 2px 8px rgba(37,99,235,0.25);
 }
 .navbar-left { display: flex; align-items: center; }
+.navbar-center { display: flex; align-items: center; justify-content: center; }
 .navbar-right { display: flex; align-items: center; justify-content: flex-end; }
 /* Nav Dropdown */
 .nav-dropdown { position: relative; }

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,8 @@
 
 <!-- Navbar -->
 <nav class="navbar">
-    <div class="navbar-left">
+    <div class="navbar-left"></div>
+    <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
@@ -36,9 +37,6 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
-                <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
-                    <i class="bi bi-people"></i> Haushalt
-                </button>
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden
                 </button>

--- a/public/profil.html
+++ b/public/profil.html
@@ -20,7 +20,8 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left">
+    <div class="navbar-left"></div>
+    <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
@@ -29,9 +30,6 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
-                <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
-                    <i class="bi bi-people"></i> Haushalt
-                </button>
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden
                 </button>
@@ -80,34 +78,45 @@
         </div>
     </div>
 
-    <!-- Passwort ändern -->
+    <!-- Haushalt -->
     <div style="background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem;margin-bottom:1rem">
         <h2 style="font-size:1.1rem;margin-bottom:1rem;display:flex;align-items:center;gap:0.4rem">
-            <i class="bi bi-key" style="color:var(--green-600)"></i> Passwort ändern
+            <i class="bi bi-people" style="color:var(--green-600)"></i> Haushalt
         </h2>
-        <div style="margin-bottom:0.75rem">
-            <label for="profilOldPass">Aktuelles Passwort</label>
-            <input type="password" id="profilOldPass" autocomplete="current-password" placeholder="Aktuelles Passwort">
-        </div>
-        <div style="margin-bottom:0.5rem">
-            <label for="profilNewPass">Neues Passwort</label>
-            <input type="password" id="profilNewPass" autocomplete="new-password" placeholder="Neues Passwort" oninput="checkProfilPwPolicy()">
-        </div>
-        <div id="profilPwPolicy" style="font-size:0.78rem;line-height:1.6;margin-bottom:0.5rem">
-            <div id="ppol-len"><i class="bi bi-x-circle"></i> Mindestens 8 Zeichen</div>
-            <div id="ppol-upper"><i class="bi bi-x-circle"></i> Mindestens 1 Grossbuchstabe</div>
-            <div id="ppol-lower"><i class="bi bi-x-circle"></i> Mindestens 1 Kleinbuchstabe</div>
-            <div id="ppol-special"><i class="bi bi-x-circle"></i> Mindestens 1 Sonderzeichen</div>
-        </div>
-        <div style="margin-bottom:0.75rem">
-            <label for="profilNewPassConfirm">Neues Passwort bestätigen</label>
-            <input type="password" id="profilNewPassConfirm" autocomplete="new-password" placeholder="Passwort wiederholen" oninput="checkProfilPwPolicy()">
-        </div>
-        <div id="ppol-match" style="font-size:0.78rem;display:none;margin-bottom:0.5rem"><i class="bi bi-x-circle"></i> Passwörter stimmen überein</div>
-        <div id="profilPwError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
-        <div id="profilPwSuccess" style="display:none;color:var(--green-600);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
-        <div style="display:flex;justify-content:flex-end">
-            <button class="btn btn-primary" onclick="changePassword()"><i class="bi bi-key"></i> Passwort ändern</button>
+        <div id="haushaltSection"></div>
+    </div>
+
+    <!-- Passwort ändern -->
+    <div style="background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem;margin-bottom:1rem">
+        <h2 style="font-size:1.1rem;margin-bottom:0;display:flex;align-items:center;gap:0.4rem;cursor:pointer" onclick="togglePasswordSection()">
+            <i class="bi bi-key" style="color:var(--green-600)"></i> Passwort ändern
+            <i class="bi bi-chevron-down" id="pwToggleIcon" style="margin-left:auto;font-size:0.85rem;color:var(--gray-400)"></i>
+        </h2>
+        <div id="passwordSection" style="display:none;margin-top:1rem">
+            <div style="margin-bottom:0.75rem">
+                <label for="profilOldPass">Aktuelles Passwort</label>
+                <input type="password" id="profilOldPass" autocomplete="current-password" placeholder="Aktuelles Passwort">
+            </div>
+            <div style="margin-bottom:0.5rem">
+                <label for="profilNewPass">Neues Passwort</label>
+                <input type="password" id="profilNewPass" autocomplete="new-password" placeholder="Neues Passwort" oninput="checkProfilPwPolicy()">
+            </div>
+            <div id="profilPwPolicy" style="font-size:0.78rem;line-height:1.6;margin-bottom:0.5rem">
+                <div id="ppol-len"><i class="bi bi-x-circle"></i> Mindestens 8 Zeichen</div>
+                <div id="ppol-upper"><i class="bi bi-x-circle"></i> Mindestens 1 Grossbuchstabe</div>
+                <div id="ppol-lower"><i class="bi bi-x-circle"></i> Mindestens 1 Kleinbuchstabe</div>
+                <div id="ppol-special"><i class="bi bi-x-circle"></i> Mindestens 1 Sonderzeichen</div>
+            </div>
+            <div style="margin-bottom:0.75rem">
+                <label for="profilNewPassConfirm">Neues Passwort bestätigen</label>
+                <input type="password" id="profilNewPassConfirm" autocomplete="new-password" placeholder="Passwort wiederholen" oninput="checkProfilPwPolicy()">
+            </div>
+            <div id="ppol-match" style="font-size:0.78rem;display:none;margin-bottom:0.5rem"><i class="bi bi-x-circle"></i> Passwörter stimmen überein</div>
+            <div id="profilPwError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
+            <div id="profilPwSuccess" style="display:none;color:var(--green-600);font-size:0.8rem;font-weight:500;margin-bottom:0.5rem"></div>
+            <div style="display:flex;justify-content:flex-end">
+                <button class="btn btn-primary" onclick="changePassword()"><i class="bi bi-key"></i> Passwort ändern</button>
+            </div>
         </div>
     </div>
 

--- a/public/profil.js
+++ b/public/profil.js
@@ -2,7 +2,16 @@ function showApp() {
     showAppBase();
     document.getElementById('profilUser').value = currentUser?.benutzername || '';
     document.getElementById('profilEmail').value = currentUser?.email || '';
+    loadHaushaltSection();
     if (typeof WebAuthnClient !== 'undefined') webauthnLadeGeraeteProfil();
+}
+
+function togglePasswordSection() {
+    const section = document.getElementById('passwordSection');
+    const icon = document.getElementById('pwToggleIcon');
+    const open = section.style.display !== 'none';
+    section.style.display = open ? 'none' : '';
+    icon.className = open ? 'bi bi-chevron-down' : 'bi bi-chevron-up';
 }
 
 if (!_redirecting) checkAuth(showApp);

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -75,7 +75,8 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left">
+    <div class="navbar-left"></div>
+    <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
@@ -86,9 +87,6 @@
             <div class="nav-dropdown-menu" id="navDropdownMenu">
                 <button onclick="openGerichteModal();closeNavDropdown()">
                     <i class="bi bi-book"></i> Eigene Gerichte
-                </button>
-                <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
-                    <i class="bi bi-people"></i> Haushalt
                 </button>
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden

--- a/public/shared.js
+++ b/public/shared.js
@@ -45,10 +45,7 @@ function showAppBase() {
     const sidebar = document.getElementById('sidebar');
     if (sidebar) sidebar.classList.remove('hidden');
     const logoutBtn = document.getElementById('logoutBtn');
-    const haushaltBtn = document.getElementById('haushaltBtn');
     if (logoutBtn) logoutBtn.style.display = '';
-    if (haushaltBtn) haushaltBtn.style.display = '';
-    ensureHaushaltModal();
 }
 
 async function submitAuth(e) {
@@ -282,6 +279,78 @@ async function openHaushalt() {
 
 function closeHaushalt() { document.getElementById('haushaltOverlay').classList.remove('active'); }
 
+// Haushalt inline on Profil page
+async function loadHaushaltSection() {
+    const section = document.getElementById('haushaltSection');
+    if (!section) return;
+    section.innerHTML = '<p style="color:var(--gray-400);text-align:center">Laden...</p>';
+
+    const meRes = await fetch('/api/auth/me');
+    if (meRes.ok) currentUser = await meRes.json();
+
+    if (currentUser.haushalt) {
+        const membersRes = await fetch('/api/haushalt/mitglieder');
+        const members = membersRes.ok ? await membersRes.json() : [];
+        const isErsteller = currentUser.haushalt.isErsteller;
+        section.innerHTML = `
+            <div style="margin-bottom:1rem">
+                <div style="font-weight:700;font-size:1rem;margin-bottom:0.25rem">${esc(currentUser.haushalt.name)}</div>
+                <div style="display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;margin-bottom:0.75rem">
+                    <span style="font-size:0.8rem;color:var(--gray-500)">Einladungscode:</span>
+                    <code style="background:var(--gray-100);padding:0.25rem 0.6rem;border-radius:6px;font-weight:700;font-size:1rem;letter-spacing:0.1em">${esc(currentUser.haushalt.code)}</code>
+                    <button class="btn btn-secondary btn-sm" onclick="navigator.clipboard.writeText('${currentUser.haushalt.code}');toast('Code kopiert')" title="Kopieren">
+                        <i class="bi bi-clipboard"></i>
+                    </button>
+                    <button class="btn btn-secondary btn-sm" onclick="shareHaushaltCode()" title="Teilen">
+                        <i class="bi bi-share"></i>
+                    </button>
+                </div>
+            </div>
+            <div style="margin-bottom:1rem">
+                <div style="font-size:0.8rem;font-weight:600;color:var(--gray-500);margin-bottom:0.4rem">Mitglieder</div>
+                ${members.map(m => {
+                    const rolleLabel = m.isErsteller ? 'Admin' : m.rolle === 'schreibend' ? 'Bearbeiten' : 'Nur lesen';
+                    const rolleColor = m.isErsteller ? 'var(--green-600)' : m.rolle === 'lesend' ? 'var(--gray-400)' : 'var(--blue-500, #3b82f6)';
+                    const rolleIcon = m.isErsteller ? 'bi-shield-fill-check' : m.rolle === 'lesend' ? 'bi-eye' : 'bi-pencil-fill';
+                    let rolleHtml = '<span style="font-size:0.7rem;color:' + rolleColor + ';font-weight:600;display:flex;align-items:center;gap:0.2rem"><i class="bi ' + rolleIcon + '"></i> ' + rolleLabel + '</span>';
+                    if (isErsteller && !m.isErsteller) {
+                        rolleHtml = '<select onchange="changeRolle(' + m.id + ',this.value)" style="font-size:0.75rem;padding:0.15rem 0.3rem;border-radius:4px;border:1px solid var(--gray-200)">' +
+                            '<option value="schreibend"' + (m.rolle === 'schreibend' ? ' selected' : '') + '>Bearbeiten</option>' +
+                            '<option value="lesend"' + (m.rolle === 'lesend' ? ' selected' : '') + '>Nur lesen</option>' +
+                            '</select>';
+                    }
+                    return '<div style="display:flex;align-items:center;gap:0.5rem;padding:0.4rem 0;font-size:0.9rem;justify-content:space-between">' +
+                        '<div style="display:flex;align-items:center;gap:0.4rem"><i class="bi bi-person-fill" style="color:var(--green-600)"></i> ' + esc(m.benutzername) + '</div>' +
+                        rolleHtml + '</div>';
+                }).join('')}
+            </div>
+            ${currentUser.haushalt.rolle === 'lesend' ? '<div style="background:var(--gray-100);border-radius:8px;padding:0.6rem 0.75rem;margin-bottom:1rem;font-size:0.8rem;color:var(--gray-500)"><i class="bi bi-eye"></i> Du hast nur Leserechte. Wende dich an den Haushalt-Admin, um Schreibrechte zu erhalten.</div>' : ''}
+            <button class="btn btn-danger" style="width:100%" onclick="leaveHaushalt()">
+                <i class="bi bi-box-arrow-right"></i> Haushalt verlassen
+            </button>`;
+    } else {
+        section.innerHTML = `
+            <p style="color:var(--gray-500);font-size:0.85rem;margin-bottom:1.25rem">
+                Erstelle einen Haushalt oder tritt einem bei, um Einkaufsliste, Wochenplan und Rezepte zu teilen.
+            </p>
+            <div style="margin-bottom:1.25rem">
+                <label>Neuen Haushalt erstellen</label>
+                <div style="display:flex;gap:0.5rem">
+                    <input type="text" id="haushaltName" placeholder="Name (z.B. Familie M\u00FCller)">
+                    <button class="btn btn-primary" onclick="createHaushalt()" style="white-space:nowrap">Erstellen</button>
+                </div>
+            </div>
+            <div style="border-top:1px solid var(--gray-200);padding-top:1.25rem">
+                <label>Haushalt beitreten</label>
+                <div style="display:flex;gap:0.5rem">
+                    <input type="text" id="haushaltCode" placeholder="Einladungscode" style="text-transform:uppercase;letter-spacing:0.1em">
+                    <button class="btn btn-primary" onclick="joinHaushalt()" style="white-space:nowrap">Beitreten</button>
+                </div>
+            </div>
+            <div id="haushaltError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500;margin-top:0.75rem"></div>`;
+    }
+}
+
 async function shareHaushaltCode() {
     const code = currentUser?.haushalt?.code;
     const name = currentUser?.haushalt?.name || 'Haushalt';
@@ -307,7 +376,7 @@ async function createHaushalt() {
     });
     if (res.ok) {
         toast('Haushalt erstellt!');
-        openHaushalt();
+        loadHaushaltSection();
         if (typeof loadItems === 'function') loadItems();
     } else {
         const data = await res.json().catch(() => null);
@@ -327,7 +396,7 @@ async function joinHaushalt() {
     if (res.ok) {
         const data = await res.json();
         toast(`Haushalt "${data.name}" beigetreten!`);
-        openHaushalt();
+        loadHaushaltSection();
         if (typeof loadItems === 'function') loadItems();
     } else {
         const data = await res.json().catch(() => null);
@@ -345,14 +414,14 @@ async function changeRolle(userId, rolle) {
         toast('Rolle ge\u00E4ndert: ' + (rolle === 'lesend' ? 'Nur lesen' : 'Bearbeiten'));
     } else {
         toast('Fehler beim \u00C4ndern der Rolle');
-        openHaushalt();
+        loadHaushaltSection();
     }
 }
 
 async function leaveHaushalt() {
     await fetch('/api/haushalt/leave', { method: 'POST' });
     toast('Haushalt verlassen');
-    closeHaushalt();
+    loadHaushaltSection();
     if (typeof loadItems === 'function') loadItems();
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'einkaufsliste-v13';
+const CACHE_NAME = 'einkaufsliste-v14';
 const ASSETS = [
     './',
     './index.html',

--- a/public/tankrabatte.html
+++ b/public/tankrabatte.html
@@ -15,7 +15,8 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left">
+    <div class="navbar-left"></div>
+    <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
@@ -24,9 +25,6 @@
                 <i class="bi bi-three-dots-vertical"></i>
             </button>
             <div class="nav-dropdown-menu" id="navDropdownMenu">
-                <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
-                    <i class="bi bi-people"></i> Haushalt
-                </button>
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden
                 </button>

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -15,7 +15,8 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left">
+    <div class="navbar-left"></div>
+    <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>
     <div class="navbar-right">
@@ -26,9 +27,6 @@
             <div class="nav-dropdown-menu" id="navDropdownMenu">
                 <button onclick="openGerichteModal();closeNavDropdown()">
                     <i class="bi bi-book"></i> Eigene Gerichte
-                </button>
-                <button onclick="openHaushalt();closeNavDropdown()" id="haushaltBtn" style="display:none">
-                    <i class="bi bi-people"></i> Haushalt
                 </button>
                 <button onclick="logout();closeNavDropdown()" id="logoutBtn" style="display:none">
                     <i class="bi bi-box-arrow-left"></i> Abmelden


### PR DESCRIPTION
## Summary
- **Haushalt auf Profil-Seite**: Haushalt-Einstellungen direkt als Card auf der Profil-Seite (erstellen, beitreten, Mitglieder, verlassen). Haushalt-Button aus Dropdown entfernt.
- **Passwort einklappbar**: Standardmässig zugeklappt, Klick auf Titel klappt auf/zu.
- **Titel zentriert**: "HaushaltPLUS" zentriert in Navbar via 3-Spalten Grid.

## Test plan
- [ ] Profil-Seite: Haushalt-Sektion angezeigt (mit/ohne Haushalt)
- [ ] Haushalt erstellen/beitreten/verlassen funktioniert inline
- [ ] Passwort-Bereich: zugeklappt, Klick klappt auf/zu
- [ ] Navbar: "HaushaltPLUS" zentriert auf allen Seiten
- [ ] Dreipunkt-Menü: Kein Haushalt-Button mehr

🤖 Generated with [Claude Code](https://claude.com/claude-code)