### PR TITLE
feat: Kundenkarten-Seite zum Hinterlegen von Kundenkarten (#134)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,7 @@
         <a href="wochenplan.html" class="sidebar-link"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
         <a href="rezepte.html" class="sidebar-link"><i class="bi bi-book"></i> <span>Rezepte</span></a>
         <a href="tankrabatte.html" class="sidebar-link"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="kundenkarten.html" class="sidebar-link"><i class="bi bi-credit-card"></i> <span>Karten</span></a>
         <a href="profil.html" class="sidebar-link"><i class="bi bi-person"></i> <span>Profil</span></a>
     </nav>
 </aside>

--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -5,12 +5,17 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Aktionen</title>
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="apple-mobile-web-app-title" content="Haushalt+">
+    <title>Kundenkarten — HaushaltPLUS</title>
+
     <link rel="manifest" href="manifest.json">
+    <link rel="apple-touch-icon" href="icons/icon-192.svg">
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
+
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="app.css">
-    <link rel="stylesheet" href="tankrabatte.css">
 </head>
 <body>
 
@@ -47,8 +52,8 @@
         <a href="index.html" class="sidebar-link"><i class="bi bi-cart3"></i> <span>Einkauf</span></a>
         <a href="wochenplan.html" class="sidebar-link"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
         <a href="rezepte.html" class="sidebar-link"><i class="bi bi-book"></i> <span>Rezepte</span></a>
-        <a href="tankrabatte.html" class="sidebar-link active"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
-        <a href="kundenkarten.html" class="sidebar-link"><i class="bi bi-credit-card"></i> <span>Karten</span></a>
+        <a href="tankrabatte.html" class="sidebar-link"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="kundenkarten.html" class="sidebar-link active"><i class="bi bi-credit-card"></i> <span>Karten</span></a>
         <a href="profil.html" class="sidebar-link"><i class="bi bi-person"></i> <span>Profil</span></a>
     </nav>
 </aside>
@@ -56,102 +61,79 @@
 <div id="appContent" class="app-content hidden">
 <div class="container">
 
-    <!-- Einkaufsaktionen -->
     <h2 style="font-size:1.1rem;margin-bottom:0.75rem;display:flex;align-items:center;gap:0.4rem">
-        <i class="bi bi-tag" style="color:var(--green-600)"></i> Einkaufsaktionen
+        <i class="bi bi-credit-card" style="color:var(--green-600)"></i> Kundenkarten
     </h2>
 
-    <div style="display:flex;gap:0.5rem;margin-bottom:1rem;flex-wrap:wrap">
-        <input type="text" id="aktionenSuche" placeholder="Produkt suchen…" onkeydown="if(event.key==='Enter')searchAktionen()" style="flex:1;min-width:120px">
-        <select id="aktionenLaden" onchange="searchAktionen()" style="min-width:100px">
-            <option value="">Alle Läden</option>
-            <option>Aldi</option>
-            <option>Coop</option>
-            <option>Coop Megastore</option>
-            <option>Denner</option>
-            <option>Lidl</option>
-            <option>Migros</option>
-            <option>OTTO'S</option>
-            <option>SPAR</option>
-            <option>Volg</option>
-        </select>
-        <button class="btn btn-primary btn-sm" onclick="searchAktionen()"><i class="bi bi-search"></i></button>
-        <button class="btn btn-secondary btn-sm" onclick="refreshAktionen()" title="Aktionen neu laden"><i class="bi bi-arrow-clockwise"></i></button>
-    </div>
-    <div id="aktionenStatus" style="font-size:0.75rem;color:var(--gray-400);margin-bottom:0.5rem"></div>
-    <div id="aktionenResults"></div>
+    <div id="kartenGrid" class="tile-grid"></div>
 
-    <!-- Tankrabatte -->
-    <h2 style="font-size:1.1rem;margin-top:2rem;margin-bottom:1rem;display:flex;align-items:center;gap:0.4rem">
-        <i class="bi bi-fuel-pump" style="color:var(--green-600)"></i> Tankrabatte
-    </h2>
-
-    <div id="tankrabatteLoading" style="text-align:center;padding:2rem;color:var(--gray-400)">
-        <i class="bi bi-arrow-repeat spin" style="font-size:1.5rem"></i>
-        <p style="margin-top:0.5rem">Gutscheine werden geladen...</p>
+    <div id="kartenEmpty" style="display:none;text-align:center;padding:2rem 1rem;color:var(--gray-400)">
+        <i class="bi bi-credit-card" style="font-size:2.5rem;display:block;margin-bottom:0.5rem"></i>
+        <p>Noch keine Kundenkarten hinterlegt.</p>
+        <p style="font-size:0.8rem">Tippe auf + um eine Karte hinzuzufügen.</p>
     </div>
 
-    <div id="tankrabatteContent" style="display:none">
-        <!-- Coop Pronto -->
-        <div class="anbieter-section" id="sectionCoopPronto">
-            <div class="anbieter-header">
-                <span class="anbieter-name">Coop Pronto</span>
-                <span class="anbieter-badge" id="badgeCoopPronto">0</span>
-            </div>
-            <div class="gutschein-liste" id="listeCoopPronto"></div>
+    <!-- FAB -->
+    <button class="fab" onclick="openAddKarte()" title="Neue Kundenkarte">
+        <i class="bi bi-plus-lg"></i>
+    </button>
+
+</div>
+</div>
+
+<!-- Modal: Karte hinzufügen/bearbeiten -->
+<div class="modal-overlay" id="karteOverlay" onclick="if(event.target===this)closeKarteModal()">
+    <div class="modal" style="max-width:420px">
+        <div class="modal-header">
+            <h2 id="karteModalTitle"><i class="bi bi-credit-card"></i> Neue Kundenkarte</h2>
+            <button class="modal-close" onclick="closeKarteModal()"><i class="bi bi-x-lg"></i></button>
         </div>
-
-        <!-- Migrol -->
-        <div class="anbieter-section" id="sectionMigrol">
-            <div class="anbieter-header">
-                <span class="anbieter-name">Migrol</span>
-                <span class="anbieter-badge" id="badgeMigrol">0</span>
+        <div class="modal-body">
+            <input type="hidden" id="karteEditId">
+            <div style="margin-bottom:0.75rem">
+                <label for="karteName">Name</label>
+                <input type="text" id="karteName" placeholder="z.B. Migros Cumulus" maxlength="200">
             </div>
-            <div class="gutschein-liste" id="listeMigrol"></div>
-        </div>
-
-        <!-- Shell -->
-        <div class="anbieter-section" id="sectionShell">
-            <div class="anbieter-header">
-                <span class="anbieter-name">Shell</span>
-                <span class="anbieter-badge" id="badgeShell">0</span>
+            <div style="margin-bottom:0.75rem">
+                <label for="karteNummer">Kartennummer</label>
+                <input type="text" id="karteNummer" placeholder="z.B. 76 1234 5678 9" maxlength="500">
             </div>
-            <div class="gutschein-liste" id="listeShell"></div>
-        </div>
-
-        <!-- AVIA -->
-        <div class="anbieter-section" id="sectionAvia">
-            <div class="anbieter-header">
-                <span class="anbieter-name">AVIA</span>
-                <span class="anbieter-badge" id="badgeAvia">0</span>
+            <div style="margin-bottom:1rem">
+                <label for="karteNotiz">Notiz (optional)</label>
+                <input type="text" id="karteNotiz" placeholder="z.B. Familie" maxlength="500">
             </div>
-            <div class="gutschein-liste" id="listeAvia"></div>
+            <div id="karteError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500;margin-bottom:0.75rem"></div>
+            <div style="display:flex;gap:0.5rem;justify-content:flex-end">
+                <button class="btn btn-secondary" onclick="closeKarteModal()">Abbrechen</button>
+                <button class="btn btn-primary" onclick="saveKarte()"><i class="bi bi-check-lg"></i> Speichern</button>
+            </div>
         </div>
-    </div>
-
-    <div id="tankrabatteError" style="display:none;text-align:center;padding:2rem;color:var(--red-500)">
-        <i class="bi bi-exclamation-triangle" style="font-size:1.5rem"></i>
-        <p style="margin-top:0.5rem" id="tankrabatteErrorMsg">Fehler beim Laden.</p>
-        <button class="btn btn-secondary btn-sm" onclick="ladeGutscheine()" style="margin-top:0.75rem">
-            <i class="bi bi-arrow-clockwise"></i> Erneut versuchen
-        </button>
-    </div>
-
-    <div id="tankrabatteFooter" style="display:none;text-align:center;margin-top:1.5rem">
-        <button class="btn btn-secondary btn-sm" onclick="ladeGutscheine()">
-            <i class="bi bi-arrow-clockwise"></i> Aktualisieren
-        </button>
-        <p style="font-size:0.7rem;color:var(--gray-400);margin-top:0.5rem" id="letzteAktualisierung"></p>
     </div>
 </div>
+
+<!-- Delete Confirm -->
+<div class="modal-overlay" id="deleteOverlay" onclick="if(event.target===this)closeDeleteConfirm()">
+    <div class="modal" style="max-width:360px">
+        <div class="modal-header">
+            <h2><i class="bi bi-trash"></i> Karte löschen</h2>
+            <button class="modal-close" onclick="closeDeleteConfirm()"><i class="bi bi-x-lg"></i></button>
+        </div>
+        <div class="modal-body">
+            <p style="margin-bottom:1rem">Möchtest du diese Kundenkarte wirklich löschen?</p>
+            <div style="display:flex;gap:0.5rem;justify-content:flex-end">
+                <button class="btn btn-secondary" onclick="closeDeleteConfirm()">Abbrechen</button>
+                <button class="btn btn-danger" onclick="confirmDelete()"><i class="bi bi-trash"></i> Löschen</button>
+            </div>
+        </div>
+    </div>
 </div>
 
 <!-- Login Screen -->
 <div id="loginScreen" class="login-screen">
     <div class="login-card">
         <div class="login-header">
-            <i class="bi bi-tag" style="font-size:2.5rem;color:var(--green-600)"></i>
-            <h1 style="font-size:1.5rem;margin-top:0.5rem">Aktionen</h1>
+            <i class="bi bi-credit-card" style="font-size:2.5rem;color:var(--green-600)"></i>
+            <h1 style="font-size:1.5rem;margin-top:0.5rem">Kundenkarten</h1>
             <p style="color:var(--gray-500);font-size:0.85rem;margin-top:0.25rem">Anmelden</p>
         </div>
         <form onsubmit="submitAuth(event)">
@@ -177,13 +159,14 @@
     </div>
 </div>
 
-<!-- Toast -->
+<!-- Toasts -->
 <div class="toast-container" id="toasts"></div>
 
 <script src="lib/simplewebauthn-browser.min.js"></script>
 <script src="webauthn.js"></script>
 <script src="shared.js"></script>
 <script src="bugreport.js"></script>
-<script src="tankrabatte.js"></script>
+<script src="kundenkarten.js"></script>
+
 </body>
 </html>

--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -1,0 +1,141 @@
+let karten = [];
+let deleteTargetId = null;
+
+function showApp() {
+    showAppBase();
+    loadKarten();
+}
+
+async function loadKarten() {
+    try {
+        const res = await fetch('/api/kundenkarten');
+        if (res.status === 401) { showLogin(); return; }
+        karten = await res.json();
+    } catch (e) {
+        console.error('Kundenkarten laden fehlgeschlagen', e);
+        karten = [];
+    }
+    renderKarten();
+}
+
+function esc(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function renderKarten() {
+    const grid = document.getElementById('kartenGrid');
+    const empty = document.getElementById('kartenEmpty');
+
+    if (karten.length === 0) {
+        grid.innerHTML = '';
+        empty.style.display = '';
+        return;
+    }
+
+    empty.style.display = 'none';
+    grid.innerHTML = karten.map(k => `
+        <div class="tile">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.5rem">
+                <div style="display:flex;align-items:center;gap:0.4rem;font-weight:700;font-size:0.95rem;color:var(--gray-800)">
+                    <i class="bi bi-credit-card" style="color:var(--green-600)"></i>
+                    ${esc(k.name)}
+                </div>
+                <div style="display:flex;gap:0.25rem">
+                    <button class="btn-icon" onclick="openEditKarte(${k.id})" title="Bearbeiten"><i class="bi bi-pencil"></i></button>
+                    <button class="btn-icon" onclick="openDeleteConfirm(${k.id})" title="Löschen" style="color:var(--red-500)"><i class="bi bi-trash"></i></button>
+                </div>
+            </div>
+            <div style="font-size:1.2rem;font-weight:700;letter-spacing:0.08em;color:var(--gray-700);font-family:monospace;word-break:break-all;margin-bottom:0.25rem">
+                ${esc(k.kartennummer)}
+            </div>
+            ${k.notiz ? '<div style="font-size:0.78rem;color:var(--gray-400)">' + esc(k.notiz) + '</div>' : ''}
+        </div>
+    `).join('');
+}
+
+function openAddKarte() {
+    document.getElementById('karteEditId').value = '';
+    document.getElementById('karteName').value = '';
+    document.getElementById('karteNummer').value = '';
+    document.getElementById('karteNotiz').value = '';
+    document.getElementById('karteError').style.display = 'none';
+    document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Neue Kundenkarte';
+    document.getElementById('karteOverlay').classList.add('active');
+}
+
+function openEditKarte(id) {
+    const k = karten.find(x => x.id === id);
+    if (!k) return;
+    document.getElementById('karteEditId').value = id;
+    document.getElementById('karteName').value = k.name;
+    document.getElementById('karteNummer').value = k.kartennummer;
+    document.getElementById('karteNotiz').value = k.notiz || '';
+    document.getElementById('karteError').style.display = 'none';
+    document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Karte bearbeiten';
+    document.getElementById('karteOverlay').classList.add('active');
+}
+
+function closeKarteModal() {
+    document.getElementById('karteOverlay').classList.remove('active');
+}
+
+async function saveKarte() {
+    const id = document.getElementById('karteEditId').value;
+    const name = document.getElementById('karteName').value.trim();
+    const kartennummer = document.getElementById('karteNummer').value.trim();
+    const notiz = document.getElementById('karteNotiz').value.trim();
+    const errEl = document.getElementById('karteError');
+
+    if (!name || !kartennummer) {
+        errEl.textContent = 'Bitte Name und Kartennummer eingeben.';
+        errEl.style.display = '';
+        return;
+    }
+
+    const method = id ? 'PUT' : 'POST';
+    const url = id ? `/api/kundenkarten/${id}` : '/api/kundenkarten';
+    const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, kartennummer, notiz })
+    });
+
+    if (res.ok) {
+        toast(id ? 'Karte aktualisiert' : 'Karte hinzugefügt');
+        closeKarteModal();
+        loadKarten();
+    } else {
+        const data = await res.json().catch(() => null);
+        errEl.textContent = data?.error || 'Fehler beim Speichern.';
+        errEl.style.display = '';
+    }
+}
+
+function openDeleteConfirm(id) {
+    deleteTargetId = id;
+    document.getElementById('deleteOverlay').classList.add('active');
+}
+
+function closeDeleteConfirm() {
+    document.getElementById('deleteOverlay').classList.remove('active');
+    deleteTargetId = null;
+}
+
+async function confirmDelete() {
+    if (!deleteTargetId) return;
+    const res = await fetch(`/api/kundenkarten/${deleteTargetId}`, { method: 'DELETE' });
+    if (res.ok) {
+        toast('Karte gelöscht');
+        loadKarten();
+    } else {
+        toast('Fehler beim Löschen', true);
+    }
+    closeDeleteConfirm();
+}
+
+// Keyboard
+document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') { closeKarteModal(); closeDeleteConfirm(); }
+});
+
+if (!_redirecting) checkAuth(showApp);

--- a/public/profil.html
+++ b/public/profil.html
@@ -53,6 +53,7 @@
         <a href="wochenplan.html" class="sidebar-link"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
         <a href="rezepte.html" class="sidebar-link"><i class="bi bi-book"></i> <span>Rezepte</span></a>
         <a href="tankrabatte.html" class="sidebar-link"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="kundenkarten.html" class="sidebar-link"><i class="bi bi-credit-card"></i> <span>Karten</span></a>
         <a href="profil.html" class="sidebar-link active"><i class="bi bi-person"></i> <span>Profil</span></a>
     </nav>
 </aside>

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -111,6 +111,7 @@
         <a href="wochenplan.html" class="sidebar-link"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
         <a href="rezepte.html" class="sidebar-link active"><i class="bi bi-book"></i> <span>Rezepte</span></a>
         <a href="tankrabatte.html" class="sidebar-link"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="kundenkarten.html" class="sidebar-link"><i class="bi bi-credit-card"></i> <span>Karten</span></a>
         <a href="profil.html" class="sidebar-link"><i class="bi bi-person"></i> <span>Profil</span></a>
     </nav>
 </aside>

--- a/public/shared.js
+++ b/public/shared.js
@@ -4,7 +4,7 @@
 let _redirecting = false;
 (function() {
     const page = location.pathname.split('/').pop() || 'index.html';
-    const trackablePages = ['index.html', 'wochenplan.html', 'rezepte.html', 'tankrabatte.html'];
+    const trackablePages = ['index.html', 'wochenplan.html', 'rezepte.html', 'tankrabatte.html', 'kundenkarten.html'];
     if (trackablePages.includes(page)) {
         const lastPage = localStorage.getItem('lastVisitedPage');
         if (lastPage && lastPage !== page && trackablePages.includes(lastPage)) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'einkaufsliste-v14';
+const CACHE_NAME = 'einkaufsliste-v15';
 const ASSETS = [
     './',
     './index.html',
@@ -10,6 +10,8 @@ const ASSETS = [
     './tankrabatte.html',
     './profil.html',
     './profil.js',
+    './kundenkarten.html',
+    './kundenkarten.js',
     './app.css',
     './app.js',
     './shared.js',

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -51,6 +51,7 @@
         <a href="wochenplan.html" class="sidebar-link active"><i class="bi bi-calendar-week"></i> <span>Woche</span></a>
         <a href="rezepte.html" class="sidebar-link"><i class="bi bi-book"></i> <span>Rezepte</span></a>
         <a href="tankrabatte.html" class="sidebar-link"><i class="bi bi-tag"></i> <span>Aktionen</span></a>
+        <a href="kundenkarten.html" class="sidebar-link"><i class="bi bi-credit-card"></i> <span>Karten</span></a>
         <a href="profil.html" class="sidebar-link"><i class="bi bi-person"></i> <span>Profil</span></a>
     </nav>
 </aside>

--- a/server.js
+++ b/server.js
@@ -1700,6 +1700,98 @@ app.delete('/api/wochenplan/:id', requireAuth, async (req, res) => {
   }
 });
 
+// ==================== KUNDENKARTEN ENDPOINTS ====================
+
+app.get('/api/kundenkarten', requireAuth, async (req, res) => {
+  try {
+    const userId = req.session.userId;
+    const db = await getPool();
+    const hid = await getHaushaltId(userId, db);
+    let result;
+    if (hid != null) {
+      result = await db.request().input('hid', sql.Int, hid)
+        .query('SELECT Id, Name, Kartennummer, Notiz, ErstelltAm FROM Kundenkarte WHERE HaushaltId=@hid ORDER BY Name');
+    } else {
+      result = await db.request().input('uid', sql.Int, userId)
+        .query('SELECT Id, Name, Kartennummer, Notiz, ErstelltAm FROM Kundenkarte WHERE BenutzerId=@uid AND HaushaltId IS NULL ORDER BY Name');
+    }
+    res.json(result.recordset.map(r => ({ id: r.Id, name: r.Name, kartennummer: r.Kartennummer, notiz: r.Notiz || '', erstelltAm: r.ErstelltAm })));
+  } catch (e) {
+    console.error('Kundenkarten GET Fehler:', e);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
+});
+
+app.post('/api/kundenkarten', requireAuth, async (req, res) => {
+  try {
+    const userId = req.session.userId;
+    const db = await getPool();
+    if (!await canWrite(userId, db)) return res.status(403).json({ error: 'Keine Schreibrechte.' });
+    const hid = await getHaushaltId(userId, db);
+    const { name, kartennummer, notiz } = req.body;
+    if (!name || !kartennummer) return res.status(400).json({ error: 'Name und Kartennummer erforderlich.' });
+    const result = await db.request()
+      .input('name', sql.NVarChar, name.trim())
+      .input('kartennummer', sql.NVarChar, kartennummer.trim())
+      .input('notiz', sql.NVarChar, (notiz || '').trim() || null)
+      .input('uid', sql.Int, userId)
+      .input('hid', sql.Int, hid)
+      .query('INSERT INTO Kundenkarte (Name, Kartennummer, Notiz, BenutzerId, HaushaltId) OUTPUT INSERTED.Id, INSERTED.ErstelltAm VALUES (@name, @kartennummer, @notiz, @uid, @hid)');
+    const row = result.recordset[0];
+    res.json({ id: row.Id, erstelltAm: row.ErstelltAm });
+  } catch (e) {
+    console.error('Kundenkarten POST Fehler:', e);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
+});
+
+app.put('/api/kundenkarten/:id', requireAuth, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const userId = req.session.userId;
+    const db = await getPool();
+    if (!await canWrite(userId, db)) return res.status(403).json({ error: 'Keine Schreibrechte.' });
+    const hid = await getHaushaltId(userId, db);
+    const { name, kartennummer, notiz } = req.body;
+    if (!name || !kartennummer) return res.status(400).json({ error: 'Name und Kartennummer erforderlich.' });
+    const where = hid != null ? 'Id=@id AND HaushaltId=@hid' : 'Id=@id AND BenutzerId=@uid AND HaushaltId IS NULL';
+    const result = await db.request()
+      .input('id', sql.Int, id)
+      .input('name', sql.NVarChar, name.trim())
+      .input('kartennummer', sql.NVarChar, kartennummer.trim())
+      .input('notiz', sql.NVarChar, (notiz || '').trim() || null)
+      .input('uid', sql.Int, userId)
+      .input('hid', sql.Int, hid)
+      .query(`UPDATE Kundenkarte SET Name=@name, Kartennummer=@kartennummer, Notiz=@notiz WHERE ${where}`);
+    if (result.rowsAffected[0] > 0) res.json({});
+    else res.status(404).json({ error: 'Karte nicht gefunden.' });
+  } catch (e) {
+    console.error('Kundenkarten PUT Fehler:', e);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
+});
+
+app.delete('/api/kundenkarten/:id', requireAuth, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const userId = req.session.userId;
+    const db = await getPool();
+    if (!await canWrite(userId, db)) return res.status(403).json({ error: 'Keine Schreibrechte.' });
+    const hid = await getHaushaltId(userId, db);
+    const where = hid != null ? 'Id=@id AND HaushaltId=@hid' : 'Id=@id AND BenutzerId=@uid AND HaushaltId IS NULL';
+    const result = await db.request()
+      .input('id', sql.Int, id)
+      .input('uid', sql.Int, userId)
+      .input('hid', sql.Int, hid)
+      .query(`DELETE FROM Kundenkarte WHERE ${where}`);
+    if (result.rowsAffected[0] > 0) res.json({});
+    else res.status(404).json({ error: 'Karte nicht gefunden.' });
+  } catch (e) {
+    console.error('Kundenkarten DELETE Fehler:', e);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
+});
+
 // ==================== ADMIN ENDPOINTS ====================
 
 app.get('/api/admin/benutzer', requireAuth, async (req, res) => {
@@ -2847,6 +2939,19 @@ async function startup() {
       IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name='IX_WebAuthnCredential_BenutzerId')
       CREATE INDEX IX_WebAuthnCredential_BenutzerId
           ON WebAuthnCredential(BenutzerId)`);
+
+    await db.request().query(`
+      IF NOT EXISTS (SELECT * FROM sys.tables WHERE name='Kundenkarte')
+      CREATE TABLE Kundenkarte (
+          Id INT IDENTITY(1,1) PRIMARY KEY,
+          Name NVARCHAR(200) NOT NULL,
+          Kartennummer NVARCHAR(500) NOT NULL,
+          Notiz NVARCHAR(500) NULL,
+          BenutzerId INT NOT NULL,
+          HaushaltId INT NULL,
+          ErstelltAm DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
+          FOREIGN KEY (BenutzerId) REFERENCES Benutzer(Id)
+      )`);
 
     // Ensure HaushaltRolle column on Benutzer (for existing databases)
     await db.request().query(`


### PR DESCRIPTION
## Summary
- Neue **Kundenkarten-Seite** zum Verwalten von Kundenkarten (Cumulus, Supercard, etc.)
- Karten als Tiles mit Name, Kartennummer (Monospace, gross) und optionaler Notiz
- Add/Edit Modal und Delete-Bestätigung
- Vollständiges CRUD: `GET/POST/PUT/DELETE /api/kundenkarten`
- Haushalt-Sharing: Karten werden mit allen Haushaltsmitgliedern geteilt
- Sidebar-Link "Karten" auf allen Seiten

## Changes
- `server.js`: Neue `Kundenkarte`-Tabelle + 4 API-Endpoints
- `kundenkarten.html` + `kundenkarten.js`: Neue Seite
- 5 HTML-Seiten: Sidebar-Link hinzugefügt
- `shared.js`: trackablePages erweitert
- `sw.js`: Cache v15, neue Assets

## Test plan
- [ ] Karten-Seite öffnen → leere Liste mit Hinweis
- [ ] + Button → Modal öffnet, Karte hinzufügen
- [ ] Karte bearbeiten → Modal mit Daten
- [ ] Karte löschen → Bestätigung, dann gelöscht
- [ ] Sidebar: "Karten"-Link auf allen Seiten
- [ ] Haushalt: Karten für alle Mitglieder sichtbar

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)