### PR TITLE
fix: Redirect nur beim App-Start, nicht bei Navigation

### DIFF
--- a/public/shared.js
+++ b/public/shared.js
@@ -1,13 +1,15 @@
 // -- Shared utilities across all pages --
 
-// Letzte besuchte Seite merken und Redirect
+// Letzte besuchte Seite merken und Redirect (nur beim App-Start, nicht bei normaler Navigation)
 let _redirecting = false;
 (function() {
     const page = location.pathname.split('/').pop() || 'index.html';
     const trackablePages = ['index.html', 'wochenplan.html', 'rezepte.html', 'tankrabatte.html', 'kundenkarten.html'];
     if (trackablePages.includes(page)) {
+        // Nur redirecten wenn kein Referrer (= App-Start/Direktaufruf, nicht Klick von anderer Seite)
+        const isAppStart = !document.referrer || !document.referrer.includes(location.host);
         const lastPage = localStorage.getItem('lastVisitedPage');
-        if (lastPage && lastPage !== page && trackablePages.includes(lastPage)) {
+        if (isAppStart && lastPage && lastPage !== page && trackablePages.includes(lastPage)) {
             _redirecting = true;
             location.replace(lastPage);
             return;


### PR DESCRIPTION
## Summary
- **Bug**: Klick auf Sidebar-Links (Woche, Rezepte, Aktionen) leitete immer zurück zur Einkauf-Seite
- **Ursache**: Last-visited-page Redirect feuerte bei **jedem** Seitenaufruf, nicht nur beim App-Start
- **Fix**: Prüft `document.referrer` — Redirect nur wenn kein Referrer (App-Start/PWA/Bookmark), nicht bei normaler Navigation innerhalb der App

## Test plan
- [ ] Sidebar: Klick auf Woche → Wochenplan öffnet sich
- [ ] Sidebar: Klick auf Rezepte → Rezepte öffnet sich
- [ ] Sidebar: Klick auf Aktionen → Aktionen öffnet sich
- [ ] App schliessen und neu öffnen → letzte besuchte Seite wird angezeigt
- [ ] PWA öffnen → letzte besuchte Seite wird angezeigt

🤖 Generated with [Claude Code](https://claude.com/claude-code)