### PR TITLE
feat: Home-Button oben links in Navbar

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -135,7 +135,9 @@
 
 <!-- Navbar -->
 <nav class="navbar">
-    <div class="navbar-left"></div>
+    <div class="navbar-left">
+        <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite"><i class="bi bi-house-door-fill"></i></a>
+    </div>
     <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,9 @@
 
 <!-- Navbar -->
 <nav class="navbar">
-    <div class="navbar-left"></div>
+    <div class="navbar-left">
+        <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite"><i class="bi bi-house-door-fill"></i></a>
+    </div>
     <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>

--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -20,7 +20,9 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left"></div>
+    <div class="navbar-left">
+        <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite"><i class="bi bi-house-door-fill"></i></a>
+    </div>
     <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>

--- a/public/profil.html
+++ b/public/profil.html
@@ -20,7 +20,9 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left"></div>
+    <div class="navbar-left">
+        <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite"><i class="bi bi-house-door-fill"></i></a>
+    </div>
     <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -75,7 +75,9 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left"></div>
+    <div class="navbar-left">
+        <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite"><i class="bi bi-house-door-fill"></i></a>
+    </div>
     <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'einkaufsliste-v15';
+const CACHE_NAME = 'einkaufsliste-v16';
 const ASSETS = [
     './',
     './index.html',

--- a/public/tankrabatte.html
+++ b/public/tankrabatte.html
@@ -15,7 +15,9 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left"></div>
+    <div class="navbar-left">
+        <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite"><i class="bi bi-house-door-fill"></i></a>
+    </div>
     <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -15,7 +15,9 @@
 <body>
 
 <nav class="navbar">
-    <div class="navbar-left"></div>
+    <div class="navbar-left">
+        <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite"><i class="bi bi-house-door-fill"></i></a>
+    </div>
     <div class="navbar-center">
         <span class="navbar-brand">HaushaltPLUS</span>
     </div>


### PR DESCRIPTION
## Summary
- **Home-Button** (Haus-Icon) oben links in der Navbar auf allen 7 Seiten
- Klick führt immer zur Einkauf-Seite (index.html)
- Navbar geht über volle Breite, Sidebar beginnt darunter

## Test plan
- [ ] Home-Button auf allen Seiten sichtbar (oben links)
- [ ] Klick auf Home → Einkauf-Seite öffnet sich
- [ ] Titel "HaushaltPLUS" bleibt zentriert
- [ ] Dreipunkt-Menü rechts funktioniert weiterhin

🤖 Generated with [Claude Code](https://claude.com/claude-code)