### PR TITLE
fix: XSS-Schwachstelle bei Rezept-URLs in onclick-Handlern behoben

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -461,7 +461,7 @@ async function searchRezept() {
     }
 
     results.innerHTML = '<div style="font-size:0.8rem;font-weight:600;color:var(--gray-500);margin-bottom:0.4rem">Rezepte</div>' +
-        data.map(r => `<div class="rezept-item" onclick="loadZutaten('${esc(r.url)}','${esc(r.name)}')">
+        data.map(r => `<div class="rezept-item" onclick="loadZutaten(${esc(JSON.stringify(r.url))},${esc(JSON.stringify(r.name))})">
             <i class="bi bi-journal-text" style="color:var(--green-600)"></i>
             <span>${esc(r.name)}</span>
             <i class="bi bi-chevron-right" style="color:var(--gray-400);margin-left:auto;font-size:0.75rem"></i>

--- a/public/rezepte.js
+++ b/public/rezepte.js
@@ -52,7 +52,7 @@ async function searchRecipes() {
     for (const [source, items] of Object.entries(grouped)) {
         html += `<div style="font-size:0.75rem;font-weight:600;color:var(--gray-500);text-transform:uppercase;margin-bottom:0.4rem;margin-top:0.75rem">${esc(source)}</div>
         <div class="recipe-grid">
-            ${items.map(r => `<div class="recipe-card" onclick="openAddToPlan('${esc(r.name).replace(/'/g,"\\'")}', '${esc(r.url).replace(/'/g,"\\'")}')">
+            ${items.map(r => `<div class="recipe-card" onclick="openAddToPlan(${esc(JSON.stringify(r.name))},${esc(JSON.stringify(r.url))})">
                 <i class="bi bi-journal-text" style="color:var(--green-600);font-size:1.1rem;flex-shrink:0"></i>
                 <span style="flex:1;font-size:0.85rem;font-weight:500">${esc(r.name)}</span>
                 <span class="source-badge">${esc(source)}</span>

--- a/public/wochenplan.js
+++ b/public/wochenplan.js
@@ -62,7 +62,7 @@ function getMeal(tag, mahlzeit) {
 
 function renderRecipeItem(r) {
     const escaped = esc(r.name);
-    return `<div class="rezept-item" onclick="loadDishZutaten('${esc(r.url)}','${escaped.replace(/'/g, "\\'")}')">
+    return `<div class="rezept-item" onclick="loadDishZutaten(${esc(JSON.stringify(r.url))},${esc(JSON.stringify(r.name))})">
         <i class="bi bi-journal-text" style="color:var(--green-600)"></i>
         <span>${escaped}</span>
         <a href="${esc(r.url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="Originalrezept öffnen" style="color:var(--gray-400);font-size:0.85rem;padding:0.2rem;flex-shrink:0"><i class="bi bi-box-arrow-up-right"></i></a>


### PR DESCRIPTION
## Summary
**Security Fix**: Externe Rezept-URLs wurden in `onclick`-Attributen mit `esc()` escaped, das nur HTML-Entities abdeckt. JavaScript-Sonderzeichen (Backticks, Backslashes) wurden nicht escaped, was XSS ermöglichte wenn eine externe Rezept-Website kompromittiert wurde.

**Fix**: `JSON.stringify()` + `esc()` für alle Werte in onclick-Kontexten — escaped sowohl JavaScript- als auch HTML-Sonderzeichen korrekt.

## Betroffene Dateien
- `app.js` — Rezeptsuche auf Einkauf-Seite
- `rezepte.js` — Rezeptliste
- `wochenplan.js` — Rezept-Items im Wochenplan

## Test plan
- [ ] Rezeptsuche funktioniert weiterhin
- [ ] Klick auf Rezepte öffnet korrekt den Plan-Dialog
- [ ] Rezepte mit Sonderzeichen im Namen werden korrekt angezeigt

🤖 Generated with [Claude Code](https://claude.com/claude-code)