### PR TITLE
feat: Kompakte Kundenkarten mit Barcode-Fullscreen-Overlay

### DIFF
--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -87,6 +87,21 @@
 </div>
 </div>
 
+<!-- Barcode Fullscreen Overlay -->
+<div class="modal-overlay" id="barcodeOverlay" onclick="if(event.target===this)closeBarcodeOverlay()" style="background:rgba(0,0,0,0.85)">
+    <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;padding:2rem;text-align:center">
+        <div style="font-size:1.3rem;font-weight:700;color:#fff;margin-bottom:0.5rem" id="barcodeKarteName"></div>
+        <div id="barcodeKarteNotiz" style="font-size:0.85rem;color:rgba(255,255,255,0.6);margin-bottom:1.5rem"></div>
+        <div style="background:#fff;border-radius:12px;padding:1.5rem 2rem;margin-bottom:1rem">
+            <svg id="barcodeDisplay"></svg>
+        </div>
+        <div style="font-size:1.3rem;font-weight:700;letter-spacing:0.1em;color:#fff;font-family:monospace;margin-bottom:2rem" id="barcodeKarteNummer"></div>
+        <button class="btn btn-secondary" onclick="closeBarcodeOverlay()" style="color:#fff;border-color:rgba(255,255,255,0.3)">
+            <i class="bi bi-x-lg"></i> Schliessen
+        </button>
+    </div>
+</div>
+
 <!-- Modal: Karte hinzufügen/bearbeiten -->
 <div class="modal-overlay" id="karteOverlay" onclick="if(event.target===this)closeKarteModal()">
     <div class="modal" style="max-width:420px">

--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -35,45 +35,50 @@ function renderKarten() {
 
     empty.style.display = 'none';
     grid.innerHTML = karten.map(k => `
-        <div class="tile">
-            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.5rem">
-                <div style="display:flex;align-items:center;gap:0.4rem;font-weight:700;font-size:0.95rem;color:var(--gray-800)">
-                    <i class="bi bi-credit-card" style="color:var(--green-600)"></i>
-                    ${esc(k.name)}
-                </div>
-                <div style="display:flex;gap:0.25rem">
-                    <button class="btn-icon" onclick="openEditKarte(${k.id})" title="Bearbeiten"><i class="bi bi-pencil"></i></button>
-                    <button class="btn-icon" onclick="openDeleteConfirm(${k.id})" title="Löschen" style="color:var(--red-500)"><i class="bi bi-trash"></i></button>
-                </div>
+        <div class="tile" style="cursor:pointer;display:flex;align-items:center;gap:0.6rem;padding:0.75rem 1rem" onclick="showBarcode(${k.id})">
+            <i class="bi bi-credit-card" style="color:var(--green-600);font-size:1.2rem;flex-shrink:0"></i>
+            <span style="font-weight:700;font-size:0.95rem;color:var(--gray-800);flex:1">${esc(k.name)}</span>
+            <div style="display:flex;gap:0.25rem;flex-shrink:0" onclick="event.stopPropagation()">
+                <button class="btn-icon" onclick="openEditKarte(${k.id})" title="Bearbeiten"><i class="bi bi-pencil"></i></button>
+                <button class="btn-icon" onclick="openDeleteConfirm(${k.id})" title="Löschen" style="color:var(--red-500)"><i class="bi bi-trash"></i></button>
             </div>
-            <div style="text-align:center;margin:0.5rem 0">
-                <svg id="barcode-${k.id}"></svg>
-            </div>
-            <div style="font-size:1.1rem;font-weight:700;letter-spacing:0.08em;color:var(--gray-700);font-family:monospace;word-break:break-all;text-align:center;margin-bottom:0.25rem">
-                ${esc(k.kartennummer)}
-            </div>
-            ${k.notiz ? '<div style="font-size:0.78rem;color:var(--gray-400)">' + esc(k.notiz) + '</div>' : ''}
         </div>
     `).join('');
+}
 
-    // Generate barcodes
-    karten.forEach(k => {
-        try {
-            const cleanNum = k.kartennummer.replace(/\s/g, '');
-            JsBarcode(`#barcode-${k.id}`, cleanNum, {
-                format: 'CODE128',
-                width: 1.5,
-                height: 50,
-                displayValue: false,
-                margin: 0,
-                background: 'transparent'
-            });
-        } catch (e) {
-            // If barcode generation fails, hide the SVG
-            const svg = document.getElementById(`barcode-${k.id}`);
-            if (svg) svg.style.display = 'none';
-        }
-    });
+// -- Barcode Fullscreen Overlay --
+function showBarcode(id) {
+    const k = karten.find(x => x.id === id);
+    if (!k) return;
+    const overlay = document.getElementById('barcodeOverlay');
+    document.getElementById('barcodeKarteName').textContent = k.name;
+    document.getElementById('barcodeKarteNummer').textContent = k.kartennummer;
+    const notizEl = document.getElementById('barcodeKarteNotiz');
+    notizEl.textContent = k.notiz || '';
+    notizEl.style.display = k.notiz ? '' : 'none';
+
+    // Generate barcode
+    const svg = document.getElementById('barcodeDisplay');
+    svg.style.display = '';
+    try {
+        const cleanNum = k.kartennummer.replace(/\s/g, '');
+        JsBarcode('#barcodeDisplay', cleanNum, {
+            format: 'CODE128',
+            width: 2,
+            height: 80,
+            displayValue: false,
+            margin: 0,
+            background: '#ffffff'
+        });
+    } catch (e) {
+        svg.style.display = 'none';
+    }
+
+    overlay.classList.add('active');
+}
+
+function closeBarcodeOverlay() {
+    document.getElementById('barcodeOverlay').classList.remove('active');
 }
 
 function openAddKarte() {
@@ -131,7 +136,7 @@ function startScan() {
             toast('Barcode erkannt: ' + decodedText);
             stopScan();
         },
-        () => {} // ignore scan errors
+        () => {}
     ).catch(err => {
         console.error('Scanner Fehler:', err);
         container.style.display = 'none';
@@ -205,7 +210,7 @@ async function confirmDelete() {
 
 // Keyboard
 document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') { closeKarteModal(); closeDeleteConfirm(); }
+    if (e.key === 'Escape') { closeBarcodeOverlay(); closeKarteModal(); closeDeleteConfirm(); }
 });
 
 if (!_redirecting) checkAuth(showApp);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'einkaufsliste-v18';
+const CACHE_NAME = 'einkaufsliste-v19';
 const ASSETS = [
     './',
     './index.html',


### PR DESCRIPTION
## Summary
- **Kompakte Kacheln**: Zeigen nur den Laden-Namen (eine Zeile) mit Edit/Delete-Buttons
- **Barcode-Overlay**: Klick auf Kachel öffnet dunkles Fullscreen-Overlay mit scanbarem Barcode, Kartennummer gross, und Schliessen-Button
- Escape-Taste schliesst das Overlay

## Test plan
- [ ] Kacheln zeigen nur den Laden-Namen
- [ ] Klick auf Kachel → Fullscreen-Barcode-Overlay öffnet sich
- [ ] Barcode ist scanbar
- [ ] Kartennummer gross unter Barcode angezeigt
- [ ] Edit/Delete-Buttons auf Kachel funktionieren ohne Overlay zu öffnen
- [ ] Escape oder Klick ausserhalb schliesst Overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)