### PR TITLE
fix: Tab-Titel einheitlich Haushalt+ auf allen Seiten

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -9,7 +9,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Haushalt+">
     <meta name="description" content="Über die HaushaltPLUS-App">
-    <title>Über — HaushaltPLUS</title>
+    <title>Haushalt+</title>
 
     <!-- PWA -->
     <link rel="manifest" href="manifest.json">

--- a/public/admin.html
+++ b/public/admin.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Admin – HaushaltPLUS</title>
+    <title>Haushalt+</title>
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="app.css">

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Haushalt+">
     <meta name="description" content="HaushaltPLUS – Einkaufsliste, Wochenplan, Rezepte und mehr">
-    <title>HaushaltPLUS</title>
+    <title>Haushalt+</title>
 
     <!-- PWA -->
     <link rel="manifest" href="manifest.json">

--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Haushalt+">
-    <title>Kundenkarten — HaushaltPLUS</title>
+    <title>Haushalt+</title>
 
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="icons/icon-192.svg">

--- a/public/profil.html
+++ b/public/profil.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Haushalt+">
-    <title>Profil — HaushaltPLUS</title>
+    <title>Haushalt+</title>
 
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="icons/icon-192.svg">

--- a/public/register.html
+++ b/public/register.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Registrieren – HaushaltPLUS</title>
+    <title>Haushalt+</title>
     <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">

--- a/public/reset.html
+++ b/public/reset.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Passwort zurücksetzen – HaushaltPLUS</title>
+    <title>Haushalt+</title>
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="app.css">

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <title>Rezepte – HaushaltPLUS</title>
+    <title>Haushalt+</title>
     <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">

--- a/public/tankrabatte.html
+++ b/public/tankrabatte.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Aktionen</title>
+    <title>Haushalt+</title>
     <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#2563eb">
-    <title>Wochenplan</title>
+    <title>Haushalt+</title>
     <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">


### PR DESCRIPTION
## Summary
Alle 10 HTML-Seiten zeigen jetzt einheitlich **Haushalt+** als Browser-Tab-Titel. Vorher waren die Titel inkonsistent (z.B. "Wochenplan", "Aktionen", "Rezepte – HaushaltPLUS", etc.).

## Test plan
- [ ] Alle Seiten: Tab zeigt "Haushalt+"

🤖 Generated with [Claude Code](https://claude.com/claude-code)