### PR TITLE
feat: show admin link in sidebar for admin users

### DIFF
--- a/public/shared.js
+++ b/public/shared.js
@@ -48,6 +48,18 @@ function showAppBase() {
     if (sidebar) sidebar.classList.remove('hidden');
     const logoutBtn = document.getElementById('logoutBtn');
     if (logoutBtn) logoutBtn.style.display = '';
+    // Show admin link in sidebar for admins
+    if (currentUser && currentUser.isAdmin) {
+        const nav = document.querySelector('.sidebar-nav');
+        if (nav && !document.getElementById('adminSidebarLink')) {
+            const link = document.createElement('a');
+            link.id = 'adminSidebarLink';
+            link.href = 'admin.html';
+            link.className = 'sidebar-link';
+            link.innerHTML = '<i class="bi bi-shield-lock"></i> <span>Admin</span>';
+            nav.appendChild(link);
+        }
+    }
 }
 
 async function submitAuth(e) {


### PR DESCRIPTION
## Summary
- Dynamically adds an "Admin" navigation link to the sidebar for users with admin privileges
- Uses the existing `currentUser.isAdmin` flag from `/api/auth/me`
- Works on all pages without modifying any HTML files

## Test plan
- [ ] Log in as admin user — "Admin" link appears at the bottom of the sidebar
- [ ] Log in as regular user — no "Admin" link visible
- [ ] Click "Admin" link — navigates to admin.html
- [ ] Verify link appears on all pages (Einkauf, Woche, Rezepte, Aktionen, Karten, Profil)

🤖 Generated with [Claude Code](https://claude.com/claude-code)