### PR TITLE
fix: prevent login screen flicker on page navigation

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -234,7 +234,7 @@ async function checkAuth() {
 }
 
 function showApp() {
-    document.getElementById('loginScreen').classList.add('hidden');
+    document.getElementById('loginScreen').classList.remove('visible');
     document.getElementById('appContent').classList.remove('hidden');
     document.getElementById('logoutBtn').style.display = '';
     loadUsers();
@@ -244,7 +244,7 @@ function showApp() {
 }
 
 function showLogin() {
-    document.getElementById('loginScreen').classList.remove('hidden');
+    document.getElementById('loginScreen').classList.add('visible');
     document.getElementById('appContent').classList.add('hidden');
 }
 

--- a/public/app.css
+++ b/public/app.css
@@ -690,12 +690,12 @@ input:focus, select:focus {
     inset: 0;
     background: var(--gray-100);
     z-index: 500;
-    display: flex;
+    display: none;
     align-items: center;
     justify-content: center;
     padding: 1rem;
 }
-.login-screen.hidden { display: none; }
+.login-screen.visible { display: flex; }
 .login-card {
     background: var(--surface);
     border-radius: var(--radius);

--- a/public/shared.js
+++ b/public/shared.js
@@ -34,7 +34,7 @@ async function checkAuth(onSuccess) {
 }
 
 function showLogin() {
-    document.getElementById('loginScreen').classList.remove('hidden');
+    document.getElementById('loginScreen').classList.add('visible');
     document.getElementById('appContent').classList.add('hidden');
     const sidebar = document.getElementById('sidebar');
     if (sidebar) sidebar.classList.add('hidden');
@@ -42,7 +42,7 @@ function showLogin() {
 }
 
 function showAppBase() {
-    document.getElementById('loginScreen').classList.add('hidden');
+    document.getElementById('loginScreen').classList.remove('visible');
     document.getElementById('appContent').classList.remove('hidden');
     const sidebar = document.getElementById('sidebar');
     if (sidebar) sidebar.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- Login screen had `display: flex` by default, causing a brief flash during async auth check on page transitions
- Changed to `display: none` by default with a `.visible` class that is only added when auth fails
- Applied consistently to `shared.js` (all pages) and `admin.html` (own auth flow)

## Test plan
- [ ] Navigate between pages while logged in — no login screen flicker
- [ ] Log out — login screen appears normally
- [ ] Log in — app content shows, login screen hides
- [ ] Open admin page as admin — no flicker
- [ ] Open any page without session — login screen shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)