### PR TITLE
feat: Kundenkarten improvements (#168, #169, #174, #175)

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -140,7 +140,10 @@
         </table>
     </div>
 
-    <h2 style="font-size:1.1rem;margin:1.5rem 0 1rem;color:var(--gray-700)"><i class="bi bi-credit-card"></i> Kundenkarten-Logos</h2>
+    <div style="display:flex;justify-content:space-between;align-items:center;margin:1.5rem 0 1rem">
+        <h2 style="font-size:1.1rem;margin:0;color:var(--gray-700)"><i class="bi bi-credit-card"></i> Kundenkarten-Logos</h2>
+        <button class="btn btn-primary btn-sm" onclick="addKkLogo()"><i class="bi bi-plus-lg"></i> Neuer Laden</button>
+    </div>
     <div id="kkLogosEmpty" style="display:none;text-align:center;padding:1rem;color:var(--gray-400);font-size:0.85rem">
         Keine Kundenkarten vorhanden.
     </div>
@@ -675,6 +678,23 @@ async function resetKkLogo() {
         loadKkLogos();
     } else {
         toast('Fehler beim Zurücksetzen');
+    }
+}
+
+async function addKkLogo() {
+    const storeName = prompt('Name des Ladens (z.B. "Migros"):');
+    if (!storeName || !storeName.trim()) return;
+    const logoUrl = prompt('Logo-URL (optional, leer lassen für automatisch):');
+    const res = await fetch('/api/admin/kundenkarten-logos', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ storeName: storeName.trim(), logoUrl: logoUrl?.trim() || null })
+    });
+    if (res.ok) {
+        toast('Logo-Eintrag erstellt');
+        loadKkLogos();
+    } else {
+        toast('Fehler beim Erstellen', true);
     }
 }
 

--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -71,6 +71,12 @@
         <i class="bi bi-credit-card" style="color:var(--green-600)"></i> Kundenkarten
     </h2>
 
+    <div id="kartenFilterCard" style="display:none;margin-bottom:0.75rem">
+        <div class="filter-bar">
+            <input type="text" id="kartenSearch" placeholder="Karte suchen…" oninput="renderKarten()">
+        </div>
+    </div>
+
     <div id="kartenGrid" class="tile-grid"></div>
 
     <div id="kartenEmpty" style="display:none;text-align:center;padding:2rem 1rem;color:var(--gray-400)">
@@ -119,7 +125,7 @@
             <div style="margin-bottom:0.75rem">
                 <label for="karteNummer">Kartennummer</label>
                 <div style="display:flex;gap:0.5rem">
-                    <input type="text" id="karteNummer" placeholder="z.B. 76 1234 5678 9" maxlength="500" style="flex:1">
+                    <input type="text" id="karteNummer" placeholder="z.B. 76 1234 5678 9" maxlength="500" style="flex:1" oninput="previewKarteValidation()">
                     <button class="btn btn-secondary btn-icon" onclick="startScan()" title="Barcode scannen" style="width:44px;height:44px;flex-shrink:0">
                         <i class="bi bi-upc-scan"></i>
                     </button>
@@ -130,6 +136,9 @@
                         <i class="bi bi-x-lg"></i> Scanner schliessen
                     </button>
                 </div>
+            </div>
+            <div id="karteNummerWarning" style="display:none;color:var(--yellow-600,#ca8a04);font-size:0.75rem;font-weight:500;margin-top:0.25rem;margin-bottom:0.5rem">
+                <i class="bi bi-exclamation-triangle"></i> <span id="karteNummerWarningText"></span>
             </div>
             <div style="margin-bottom:1rem">
                 <label for="karteNotiz">Notiz (optional)</label>

--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -79,22 +79,41 @@ function storeLogoHtml(name, size) {
 function renderKarten() {
     const grid = document.getElementById('kartenGrid');
     const empty = document.getElementById('kartenEmpty');
+    const filterCard = document.getElementById('kartenFilterCard');
+    const searchTerm = (document.getElementById('kartenSearch')?.value || '').trim().toLowerCase();
 
     if (karten.length === 0) {
         grid.innerHTML = '';
         empty.style.display = '';
+        if (filterCard) filterCard.style.display = 'none';
         return;
     }
 
     empty.style.display = 'none';
-    grid.innerHTML = karten.map(k => `
-        <div class="tile" style="cursor:pointer;display:flex;align-items:center;gap:0.6rem;padding:0.75rem 1rem" onclick="showBarcode(${k.id})">
-            ${storeLogoHtml(k.name, 24)}
+    if (filterCard) filterCard.style.display = '';
+
+    let filtered = karten;
+    if (searchTerm) {
+        filtered = karten.filter(k =>
+            k.name.toLowerCase().includes(searchTerm) ||
+            k.kartennummer.toLowerCase().includes(searchTerm) ||
+            (k.notiz && k.notiz.toLowerCase().includes(searchTerm))
+        );
+    }
+
+    if (filtered.length === 0) {
+        grid.innerHTML = '<div style="text-align:center;padding:1.5rem;color:var(--gray-400)">Keine Karten gefunden.</div>';
+        return;
+    }
+
+    grid.innerHTML = filtered.map(k => `
+        <div class="tile" style="cursor:pointer;display:flex;align-items:center;gap:0.75rem;padding:0.75rem 1rem" onclick="onKarteTileClick(event, ${k.id})">
+            ${storeLogoHtml(k.name, 48)}
             <div style="flex:1;min-width:0">
                 <span style="font-weight:700;font-size:0.95rem;color:var(--gray-800);display:block">${esc(k.name)}</span>
                 ${k.notiz ? `<span style="font-size:0.75rem;color:var(--gray-400);display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(k.notiz)}</span>` : ''}
             </div>
-            <div style="display:flex;gap:0.25rem;flex-shrink:0" onclick="event.stopPropagation()">
+            <div class="tile-actions" onclick="event.stopPropagation()">
                 <button class="btn-icon" onclick="openEditKarte(${k.id})" title="Bearbeiten"><i class="bi bi-pencil"></i></button>
                 <button class="btn-icon" onclick="openDeleteConfirm(${k.id})" title="Löschen" style="color:var(--red-500)"><i class="bi bi-trash"></i></button>
             </div>
@@ -144,6 +163,8 @@ function openAddKarte() {
     document.getElementById('karteNummer').value = '';
     document.getElementById('karteNotiz').value = '';
     document.getElementById('karteError').style.display = 'none';
+    document.getElementById('karteNummerWarning').style.display = 'none';
+    delete document.getElementById('karteNummerWarning').dataset.acknowledged;
     document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Neue Kundenkarte';
     document.getElementById('karteOverlay').classList.add('active');
     stopScan();
@@ -157,6 +178,8 @@ function openEditKarte(id) {
     document.getElementById('karteNummer').value = k.kartennummer;
     document.getElementById('karteNotiz').value = k.notiz || '';
     document.getElementById('karteError').style.display = 'none';
+    document.getElementById('karteNummerWarning').style.display = 'none';
+    delete document.getElementById('karteNummerWarning').dataset.acknowledged;
     document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Karte bearbeiten';
     document.getElementById('karteOverlay').classList.add('active');
     stopScan();
@@ -224,6 +247,19 @@ async function saveKarte() {
         return;
     }
 
+    const warnEl = document.getElementById('karteNummerWarning');
+    const warnTextEl = document.getElementById('karteNummerWarningText');
+    const warnings = validateKartennummer(kartennummer);
+    if (warnings.length > 0) {
+        warnTextEl.textContent = warnings.join(' ');
+        warnEl.style.display = '';
+        if (!warnEl.dataset.acknowledged) {
+            warnEl.dataset.acknowledged = '1';
+            return;
+        }
+    }
+    if (warnEl) { warnEl.style.display = 'none'; delete warnEl.dataset.acknowledged; }
+
     const method = id ? 'PUT' : 'POST';
     const url = id ? `/api/kundenkarten/${id}` : '/api/kundenkarten';
     const res = await fetch(url, {
@@ -265,9 +301,102 @@ async function confirmDelete() {
     closeDeleteConfirm();
 }
 
+// -- Kartennummer Validierung --
+function validateKartennummer(raw) {
+    const warnings = [];
+    const cleaned = raw.replace(/\s/g, '');
+
+    if (cleaned.length > 0 && cleaned.length < 4) {
+        warnings.push('Kartennummer scheint sehr kurz zu sein.');
+    }
+
+    if (cleaned.length > 0 && !/^[\d\s]+$/.test(raw)) {
+        warnings.push('Kartennummer enthält ungewöhnliche Zeichen (erwartet: Ziffern und Leerzeichen).');
+    }
+
+    if (/^\d{13}$/.test(cleaned)) {
+        const digits = cleaned.split('').map(Number);
+        let sum = 0;
+        for (let i = 0; i < 12; i++) {
+            sum += digits[i] * (i % 2 === 0 ? 1 : 3);
+        }
+        const checkDigit = (10 - (sum % 10)) % 10;
+        if (checkDigit !== digits[12]) {
+            warnings.push('EAN-13 Prüfziffer stimmt nicht (erwartet: ' + checkDigit + ').');
+        }
+    }
+
+    return warnings;
+}
+
+function previewKarteValidation() {
+    const val = document.getElementById('karteNummer').value.trim();
+    const warnEl = document.getElementById('karteNummerWarning');
+    const warnTextEl = document.getElementById('karteNummerWarningText');
+    if (!val) { warnEl.style.display = 'none'; return; }
+    const warnings = validateKartennummer(val);
+    if (warnings.length > 0) {
+        warnTextEl.textContent = warnings.join(' ');
+        warnEl.style.display = '';
+    } else {
+        warnEl.style.display = 'none';
+    }
+    delete warnEl.dataset.acknowledged;
+}
+
+// -- Long-Press Handler --
+let longPressTimer = null;
+let longPressTriggered = false;
+let activeTileActions = null;
+
+function onKarteTileClick(e, id) {
+    if (longPressTriggered) { longPressTriggered = false; return; }
+    if (activeTileActions) { hideAllTileActions(); return; }
+    showBarcode(id);
+}
+
+function showTileActions(tileEl) {
+    hideAllTileActions();
+    const actions = tileEl.querySelector('.tile-actions');
+    if (actions) { actions.classList.add('visible'); activeTileActions = actions; }
+}
+
+function hideAllTileActions() {
+    if (activeTileActions) { activeTileActions.classList.remove('visible'); activeTileActions = null; }
+}
+
+document.addEventListener('pointerdown', e => {
+    const tile = e.target.closest('.tile');
+    if (!tile) return;
+    if (e.target.closest('.tile-actions')) return;
+    longPressTimer = setTimeout(() => {
+        longPressTimer = null;
+        longPressTriggered = true;
+        showTileActions(tile);
+    }, 500);
+});
+
+document.addEventListener('pointerup', () => {
+    if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+});
+
+document.addEventListener('pointermove', e => {
+    if (longPressTimer && (Math.abs(e.movementX) > 5 || Math.abs(e.movementY) > 5)) {
+        clearTimeout(longPressTimer); longPressTimer = null;
+    }
+});
+
+document.addEventListener('pointercancel', () => {
+    if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+});
+
+document.addEventListener('pointerdown', e => {
+    if (activeTileActions && !e.target.closest('.tile-actions')) { hideAllTileActions(); }
+}, true);
+
 // Keyboard
 document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') { closeBarcodeOverlay(); closeKarteModal(); closeDeleteConfirm(); }
+    if (e.key === 'Escape') { hideAllTileActions(); closeBarcodeOverlay(); closeKarteModal(); closeDeleteConfirm(); }
 });
 
 if (!_redirecting) checkAuth(showApp);

--- a/server.js
+++ b/server.js
@@ -2196,10 +2196,15 @@ app.get('/api/admin/kundenkarten-logos', requireAuth, async (req, res) => {
     const db = await getPool();
     if (!await isAdmin(userId, db)) return res.status(403).json({});
     const result = await db.request()
-      .query(`SELECT DISTINCT k.Name AS storeName, l.LogoUrl AS logoUrl
-              FROM Kundenkarte k
-              LEFT JOIN KundenkartenLogo l ON LOWER(k.Name) = LOWER(l.StoreName)
-              ORDER BY k.Name`);
+      .query(`SELECT storeName, logoUrl FROM (
+                SELECT DISTINCT k.Name AS storeName, l.LogoUrl AS logoUrl
+                FROM Kundenkarte k
+                LEFT JOIN KundenkartenLogo l ON LOWER(k.Name) = LOWER(l.StoreName)
+                UNION
+                SELECT l2.StoreName AS storeName, l2.LogoUrl AS logoUrl
+                FROM KundenkartenLogo l2
+                WHERE NOT EXISTS (SELECT 1 FROM Kundenkarte k2 WHERE LOWER(k2.Name) = LOWER(l2.StoreName))
+              ) AS combined ORDER BY storeName`);
     res.json(result.recordset.map(r => ({ storeName: r.storeName, logoUrl: r.logoUrl || null })));
   } catch (err) {
     console.error('admin kundenkarten-logos get error:', err);


### PR DESCRIPTION
## Summary
- **Suche (#174):** Suchfeld auf der Kundenkarten-Seite, filtert nach Name, Nummer und Notiz
- **Long-Press & grössere Logos (#168):** Edit/Delete Buttons nur via Long-Press sichtbar (wie Einkaufsliste), Logos von 24px auf 48px vergrössert
- **Validierung (#175):** Soft-Warnung bei kurzer Nummer, ungewöhnlichen Zeichen und falscher EAN-13 Prüfziffer (live + beim Speichern)
- **Admin Logo-Verwaltung (#169):** "Neuer Laden" Button auf Admin-Seite, SQL-Query zeigt auch manuell hinzugefügte Läden

## Test plan
- [ ] Kundenkarten-Seite öffnen, Suchfeld testen (Name, Nummer, Notiz)
- [ ] Long-Press auf Karte → Edit/Delete Buttons erscheinen
- [ ] Normaler Tap → Barcode-Overlay öffnet sich
- [ ] Neue Karte mit kurzer Nummer (<4 Zeichen) → Warnung erscheint
- [ ] Neue Karte mit Buchstaben → Warnung erscheint
- [ ] 13-stellige Nummer mit falscher Prüfziffer → EAN-13 Warnung
- [ ] Trotz Warnung nochmal Speichern → Karte wird gespeichert
- [ ] Admin-Seite: "Neuer Laden" Button → neuen Logo-Eintrag erstellen
- [ ] Manuell erstellter Laden erscheint in der Admin-Logo-Liste

Closes #168, closes #169, closes #174, closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)