### PR TITLE
feat: Haushalt umbenennen (#172)

### DIFF
--- a/public/shared.js
+++ b/public/shared.js
@@ -239,7 +239,10 @@ async function openHaushalt() {
         const isErsteller = currentUser.haushalt.isErsteller;
         body.innerHTML = `
             <div style="margin-bottom:1rem">
-                <div style="font-weight:700;font-size:1rem;margin-bottom:0.25rem">${esc(currentUser.haushalt.name)}</div>
+                <div style="display:flex;align-items:center;gap:0.4rem;margin-bottom:0.25rem">
+                    <span style="font-weight:700;font-size:1rem">${esc(currentUser.haushalt.name)}</span>
+                    ${isErsteller ? '<button class="btn-icon" onclick="renameHaushalt()" title="Umbenennen" style="font-size:0.85rem;color:var(--gray-400)"><i class="bi bi-pencil"></i></button>' : ''}
+                </div>
                 <div style="display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;margin-bottom:0.75rem">
                     <span style="font-size:0.8rem;color:var(--gray-500)">Einladungscode:</span>
                     <code style="background:var(--gray-100);padding:0.25rem 0.6rem;border-radius:6px;font-weight:700;font-size:1rem;letter-spacing:0.1em">${esc(currentUser.haushalt.code)}</code>
@@ -313,7 +316,10 @@ async function loadHaushaltSection() {
         const isErsteller = currentUser.haushalt.isErsteller;
         section.innerHTML = `
             <div style="margin-bottom:1rem">
-                <div style="font-weight:700;font-size:1rem;margin-bottom:0.25rem">${esc(currentUser.haushalt.name)}</div>
+                <div style="display:flex;align-items:center;gap:0.4rem;margin-bottom:0.25rem">
+                    <span style="font-weight:700;font-size:1rem">${esc(currentUser.haushalt.name)}</span>
+                    ${isErsteller ? '<button class="btn-icon" onclick="renameHaushalt()" title="Umbenennen" style="font-size:0.85rem;color:var(--gray-400)"><i class="bi bi-pencil"></i></button>' : ''}
+                </div>
                 <div style="display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;margin-bottom:0.75rem">
                     <span style="font-size:0.8rem;color:var(--gray-500)">Einladungscode:</span>
                     <code style="background:var(--gray-100);padding:0.25rem 0.6rem;border-radius:6px;font-weight:700;font-size:1rem;letter-spacing:0.1em">${esc(currentUser.haushalt.code)}</code>
@@ -434,6 +440,24 @@ async function changeRolle(userId, rolle) {
     } else {
         toast('Fehler beim \u00C4ndern der Rolle');
         loadHaushaltSection();
+    }
+}
+
+async function renameHaushalt() {
+    const currentName = currentUser?.haushalt?.name || '';
+    const newName = prompt('Neuer Name für den Haushalt:', currentName);
+    if (!newName || newName.trim() === currentName) return;
+    const res = await fetch('/api/haushalt/name', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim() })
+    });
+    if (res.ok) {
+        toast('Haushalt umbenannt');
+        loadHaushaltSection();
+    } else {
+        const data = await res.json().catch(() => null);
+        toast(data?.error || 'Fehler beim Umbenennen', true);
     }
 }
 

--- a/server.js
+++ b/server.js
@@ -1458,6 +1458,33 @@ app.get('/api/haushalt/mitglieder', requireAuth, async (req, res) => {
   }
 });
 
+app.put('/api/haushalt/name', requireAuth, async (req, res) => {
+  try {
+    const userId = req.session.userId;
+    const name = (req.body.name || '').trim();
+    if (!name || name.length < 2) return res.status(400).json({ error: 'Name muss mindestens 2 Zeichen haben.' });
+
+    const db = await getPool();
+    const hid = await getHaushaltId(userId, db);
+    if (hid == null) return res.status(400).json({ error: 'Du bist in keinem Haushalt.' });
+
+    const check = await db.request()
+      .input('hid', sql.Int, hid)
+      .query('SELECT ErstelltVon FROM Haushalt WHERE Id=@hid');
+    const creatorId = check.recordset[0]?.ErstelltVon;
+    if (creatorId == null || creatorId !== userId) return res.status(403).json({ error: 'Nur der Ersteller kann den Haushalt umbenennen.' });
+
+    await db.request()
+      .input('name', sql.NVarChar, name)
+      .input('hid', sql.Int, hid)
+      .query('UPDATE Haushalt SET Name=@name WHERE Id=@hid');
+    res.json({});
+  } catch (err) {
+    console.error('haushalt rename error:', err);
+    res.status(500).json({ error: 'Interner Fehler.' });
+  }
+});
+
 app.put('/api/haushalt/rolle', requireAuth, async (req, res) => {
   try {
     const userId = req.session.userId;


### PR DESCRIPTION
## Summary
- Neuer API-Endpoint `PUT /api/haushalt/name` — nur der Ersteller kann den Haushalt umbenennen (min. 2 Zeichen)
- Stift-Icon neben dem Haushaltsnamen im Profil (nur für Ersteller sichtbar)
- `renameHaushalt()` Funktion mit `prompt()` Dialog, Toast-Feedback und Fehlerbehandlung

## Test plan
- [ ] Als Haushalt-Ersteller: Stift-Icon neben dem Haushaltsnamen sichtbar
- [ ] Klick auf Stift → Prompt mit aktuellem Namen → neuen Namen eingeben → Name wird aktualisiert
- [ ] Abbrechen im Prompt → nichts passiert
- [ ] Leerer Name oder <2 Zeichen → Fehlermeldung
- [ ] Als normales Mitglied: kein Stift-Icon sichtbar
- [ ] API-Test: PUT /api/haushalt/name ohne Ersteller-Rechte → 403

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)