### PR TITLE
fix: biometric login registration feedback (#173)

### DIFF
--- a/public/shared.js
+++ b/public/shared.js
@@ -601,18 +601,23 @@ async function webauthnPromptAnnehmen() {
     return;
   }
   errorEl.style.display = 'none';
+  const btns = document.querySelectorAll('#webauthnPromptOverlay button');
+  btns.forEach(b => b.disabled = true);
   try {
     await WebAuthnClient.starteRegistrierung(geraetename);
     WebAuthnClient.markiereRegistriert(currentUser.benutzername);
     document.getElementById('webauthnPromptOverlay').style.display = 'none';
-    alert('Biometrische Anmeldung erfolgreich eingerichtet!');
+    toast('Biometrische Anmeldung erfolgreich eingerichtet!');
   } catch (e) {
-    if (e.name === 'NotAllowedError') {
+    console.error('WebAuthn Prompt Registrierung Fehler:', e);
+    if (e.name === 'NotAllowedError' || e.code === 'ERROR_CEREMONY_ABORTED') {
       errorEl.textContent = 'Einrichtung abgebrochen. Du kannst es jederzeit im Profil erneut versuchen.';
     } else {
       errorEl.textContent = e.message || 'Einrichtung fehlgeschlagen.';
     }
     errorEl.style.display = '';
+  } finally {
+    btns.forEach(b => b.disabled = false);
   }
 }
 
@@ -675,14 +680,21 @@ async function webauthnGeraetEntfernen(id, name) {
 async function webauthnNeuesGeraet() {
   const name = prompt('Gerätename:');
   if (!name || !name.trim()) return;
+  const btn = document.querySelector('#webauthnGeraeteSection button');
+  if (btn) { btn.disabled = true; btn.innerHTML = '<i class="bi bi-hourglass-split"></i> Warte auf Biometrie…'; }
   try {
     await WebAuthnClient.starteRegistrierung(name.trim());
     WebAuthnClient.markiereRegistriert(currentUser.benutzername);
     webauthnLadeGeraeteProfil();
-    alert('Gerät erfolgreich registriert!');
+    toast('Gerät erfolgreich registriert!');
   } catch (e) {
-    if (e.name !== 'NotAllowedError') {
-      alert(e.message || 'Registrierung fehlgeschlagen.');
+    console.error('WebAuthn Registrierung Fehler:', e);
+    if (e.name === 'NotAllowedError' || e.code === 'ERROR_CEREMONY_ABORTED') {
+      toast('Einrichtung abgebrochen.', true);
+    } else {
+      toast(e.message || 'Registrierung fehlgeschlagen.', true);
     }
+  } finally {
+    if (btn) { btn.disabled = false; btn.innerHTML = '<i class="bi bi-plus-circle"></i> Neues Gerät hinzufügen'; }
   }
 }

--- a/public/webauthn.js
+++ b/public/webauthn.js
@@ -21,13 +21,19 @@ const WebAuthnClient = {
       body: JSON.stringify({ geraetename })
     });
     if (!optRes.ok) {
-      const err = await optRes.json();
+      const err = await optRes.json().catch(() => ({}));
       throw new Error(err.error || 'Fehler beim Starten der Registrierung.');
     }
     const options = await optRes.json();
 
     // Browser-Dialog: Fingerabdruck / Face ID
-    const attResp = await SimpleWebAuthnBrowser.startRegistration({ optionsJSON: options });
+    let attResp;
+    try {
+      attResp = await SimpleWebAuthnBrowser.startRegistration({ optionsJSON: options });
+    } catch (e) {
+      // Re-throw with original name/code preserved for caller to handle
+      throw e;
+    }
 
     const verifyRes = await fetch('/api/webauthn/register-verify', {
       method: 'POST',
@@ -35,7 +41,7 @@ const WebAuthnClient = {
       body: JSON.stringify(attResp)
     });
     if (!verifyRes.ok) {
-      const err = await verifyRes.json();
+      const err = await verifyRes.json().catch(() => ({}));
       throw new Error(err.error || 'Verifizierung fehlgeschlagen.');
     }
     return await verifyRes.json();

--- a/server.js
+++ b/server.js
@@ -1138,6 +1138,12 @@ app.post('/api/webauthn/register-verify', requireAuth, async (req, res) => {
 
     const { credential } = verification.registrationInfo;
 
+    if (!credential || !credential.publicKey) {
+      console.error('WebAuthn register-verify: credential oder publicKey fehlt', verification.registrationInfo);
+      delete req.session.webauthnChallenge;
+      return res.status(400).json({ error: 'Registrierung fehlgeschlagen: Credential-Daten unvollständig.' });
+    }
+
     const db = await getPool();
     await db.request()
       .input('benutzerId', sql.Int, req.session.userId)


### PR DESCRIPTION
## Summary
- **Hauptproblem:** `NotAllowedError` wurde in `webauthnNeuesGeraet()` still geschluckt — User sah nach Namenseingabe kein Feedback (weder Erfolg noch Fehler)
- **Fix:** Alle Fehler werden jetzt als Toast angezeigt, inkl. "Einrichtung abgebrochen" bei NotAllowedError
- **Loading-State:** Button zeigt "Warte auf Biometrie…" während der Browser-Dialog offen ist
- **Server:** Null-Check für `credential.publicKey` vor DB-Insert verhindert kryptischen 500er
- **Logging:** `console.error` bei allen WebAuthn-Fehlern für besseres Debugging

## Test plan
- [ ] Profil-Seite: "Neues Gerät hinzufügen" klicken → Name eingeben → Button zeigt Ladetext
- [ ] Biometrie abbrechen → Toast "Einrichtung abgebrochen" erscheint, Button wird zurückgesetzt
- [ ] Biometrie erfolgreich → Toast "Gerät erfolgreich registriert", Gerät in Liste sichtbar
- [ ] Post-Login Prompt: Gleicher Flow testen (Annehmen/Abbrechen)
- [ ] Browser ohne WebAuthn-Support: "Nicht unterstützt" Meldung bleibt

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)