### PR TITLE
fix: registration page renders blank

### DIFF
--- a/public/register.html
+++ b/public/register.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 
-<div class="login-screen" style="position:relative">
+<div class="login-screen visible" style="position:relative">
     <div class="login-card">
         <div class="login-header">
             <i class="bi bi-person-plus" style="font-size:2.5rem;color:var(--green-600)"></i>


### PR DESCRIPTION
## Summary
- Registration page was completely blank due to missing `visible` CSS class on the `.login-screen` div
- Commit `40cbebf` changed `.login-screen` default to `display: none`, but `register.html` was not updated to include the `.visible` class
- Added the `visible` class to the login-screen div in `register.html`

## Test plan
- [ ] Open `/register.html` — registration form should be visible
- [ ] Verify login page (`index.html`) still works without flicker
- [ ] Verify admin page still works without flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)