### PR TITLE
feat: long-press tiles to edit, delete in modal

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -415,20 +415,6 @@ input:focus, select:focus {
     line-height: 1.25;
     flex: 1;
 }
-.tile-actions {
-    display: none;
-    gap: 0.3rem;
-    flex-shrink: 0;
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    background: var(--surface);
-    padding: 0.25rem;
-    border-radius: 8px;
-    box-shadow: var(--shadow-md);
-    z-index: 10;
-}
-.tile-actions.visible { display: flex; }
 
 /* Tile body info */
 .tile-info {

--- a/public/app.js
+++ b/public/app.js
@@ -174,6 +174,8 @@ function openModal(id) {
     document.getElementById('einheit').value = 'St\u00FCck';
     document.getElementById('laden').value = '';
     document.getElementById('datum').value = '';
+    const deleteBtn = document.getElementById('modalDeleteBtn');
+    deleteBtn.style.display = 'none';
     if (id !== undefined) {
         const item = items.find(i => i.id === id);
         if (item) {
@@ -185,6 +187,8 @@ function openModal(id) {
             document.getElementById('einheit').value = item.einheit;
             document.getElementById('laden').value = item.laden || '';
             document.getElementById('datum').value = item.datum || '';
+            deleteBtn.style.display = '';
+            deleteBtn.onclick = () => { closeModal(); openDelete(id); };
         }
     }
     document.getElementById('modalOverlay').classList.add('active');
@@ -375,15 +379,11 @@ function renderTile(item) {
         const checkIcon = isGekauft ? 'bi-check-circle-fill' : 'bi-circle';
         const doneBadge = isGekauft ? '<span class="tile-badge done"><i class="bi bi-check-lg"></i> Gekauft</span>' : badgeHtml;
 
-        return `<div class="tile ${tileCls}" onclick="onTileClick(event,${item.id})" style="cursor:pointer">
+        return `<div class="tile ${tileCls}" data-id="${item.id}" onclick="onTileClick(event,${item.id})" style="cursor:pointer">
             <div class="tile-header">
                 <div style="display:flex;align-items:center;gap:0.5rem;flex:1;min-width:0">
                     <i class="bi ${checkIcon}" style="font-size:1rem;flex-shrink:0;color:${isGekauft ? 'var(--green-600)' : 'var(--gray-300)'}"></i>
                     <div class="tile-title">${esc(item.artikel)}</div>
-                </div>
-                <div class="tile-actions" onclick="event.stopPropagation()">
-                    <button class="btn btn-secondary btn-icon" onclick="openModal(${item.id})" title="Bearbeiten"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-danger btn-icon" onclick="openDelete(${item.id})" title="L\u00F6schen"><i class="bi bi-trash"></i></button>
                 </div>
             </div>
             <div class="tile-info">
@@ -645,39 +645,19 @@ let longPressTriggered = false;
 
 function onTileClick(e, id) {
     if (longPressTriggered) { longPressTriggered = false; return; }
-    if (activeTileActions) { hideAllTileActions(); return; }
     toggleGekauft(id);
 }
 
-// -- Long-press for tile actions --
+// -- Long-press to open edit modal --
 let longPressTimer = null;
-let activeTileActions = null;
-
-function showTileActions(tileEl) {
-    hideAllTileActions();
-    const actions = tileEl.querySelector('.tile-actions');
-    if (actions) {
-        actions.classList.add('visible');
-        activeTileActions = actions;
-    }
-}
-
-function hideAllTileActions() {
-    if (activeTileActions) {
-        activeTileActions.classList.remove('visible');
-        activeTileActions = null;
-    }
-}
 
 document.addEventListener('pointerdown', e => {
     const tile = e.target.closest('.tile');
-    if (!tile) return;
-    // Ignore if tapping on already-visible actions
-    if (e.target.closest('.tile-actions')) return;
+    if (!tile || !tile.dataset.id) return;
     longPressTimer = setTimeout(() => {
         longPressTimer = null;
         longPressTriggered = true;
-        showTileActions(tile);
+        openModal(parseInt(tile.dataset.id));
     }, 500);
 });
 
@@ -695,16 +675,9 @@ document.addEventListener('pointercancel', () => {
     if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
 });
 
-// Hide actions when tapping elsewhere
-document.addEventListener('pointerdown', e => {
-    if (activeTileActions && !e.target.closest('.tile-actions')) {
-        hideAllTileActions();
-    }
-}, true);
-
 // -- Keyboard --
 document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') { closeModal(); closeDelete(); closeReactivate(); closeHaushalt(); closeRezept(); hideAllTileActions(); }
+    if (e.key === 'Escape') { closeModal(); closeDelete(); closeReactivate(); closeHaushalt(); closeRezept(); }
 });
 
 // -- PWA: Service Worker --

--- a/public/index.html
+++ b/public/index.html
@@ -175,11 +175,16 @@
                         <input type="date" id="datum">
                     </div>
                 </div>
-                <div class="modal-footer" style="padding:1.25rem 0 0; border-top:none;">
-                    <button type="button" class="btn btn-secondary" onclick="closeModal()">Abbrechen</button>
-                    <button type="submit" class="btn btn-primary" id="saveBtn">
-                        <i class="bi bi-check-lg"></i> Hinzufügen
+                <div class="modal-footer" style="padding:1.25rem 0 0; border-top:none; justify-content:space-between;">
+                    <button type="button" class="btn btn-danger" id="modalDeleteBtn" style="display:none">
+                        <i class="bi bi-trash"></i> Löschen
                     </button>
+                    <div style="display:flex;gap:0.5rem">
+                        <button type="button" class="btn btn-secondary" onclick="closeModal()">Abbrechen</button>
+                        <button type="submit" class="btn btn-primary" id="saveBtn">
+                            <i class="bi bi-check-lg"></i> Hinzufügen
+                        </button>
+                    </div>
                 </div>
             </form>
         </div>

--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -145,9 +145,14 @@
                 <input type="text" id="karteNotiz" placeholder="z.B. Familie" maxlength="500">
             </div>
             <div id="karteError" style="display:none;color:var(--red-500);font-size:0.8rem;font-weight:500;margin-bottom:0.75rem"></div>
-            <div style="display:flex;gap:0.5rem;justify-content:flex-end">
-                <button class="btn btn-secondary" onclick="closeKarteModal()">Abbrechen</button>
-                <button class="btn btn-primary" onclick="saveKarte()"><i class="bi bi-check-lg"></i> Speichern</button>
+            <div style="display:flex;gap:0.5rem;justify-content:space-between">
+                <button class="btn btn-danger" id="karteModalDeleteBtn" style="display:none">
+                    <i class="bi bi-trash"></i> Löschen
+                </button>
+                <div style="display:flex;gap:0.5rem;margin-left:auto">
+                    <button class="btn btn-secondary" onclick="closeKarteModal()">Abbrechen</button>
+                    <button class="btn btn-primary" onclick="saveKarte()"><i class="bi bi-check-lg"></i> Speichern</button>
+                </div>
             </div>
         </div>
     </div>

--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -107,15 +107,11 @@ function renderKarten() {
     }
 
     grid.innerHTML = filtered.map(k => `
-        <div class="tile" style="cursor:pointer;display:flex;align-items:center;gap:0.75rem;padding:0.75rem 1rem" onclick="onKarteTileClick(event, ${k.id})">
+        <div class="tile" data-id="${k.id}" style="cursor:pointer;display:flex;align-items:center;gap:0.75rem;padding:0.75rem 1rem" onclick="onKarteTileClick(event, ${k.id})">
             ${storeLogoHtml(k.name, 48)}
             <div style="flex:1;min-width:0">
                 <span style="font-weight:700;font-size:0.95rem;color:var(--gray-800);display:block">${esc(k.name)}</span>
                 ${k.notiz ? `<span style="font-size:0.75rem;color:var(--gray-400);display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(k.notiz)}</span>` : ''}
-            </div>
-            <div class="tile-actions" onclick="event.stopPropagation()">
-                <button class="btn-icon" onclick="openEditKarte(${k.id})" title="Bearbeiten"><i class="bi bi-pencil"></i></button>
-                <button class="btn-icon" onclick="openDeleteConfirm(${k.id})" title="Löschen" style="color:var(--red-500)"><i class="bi bi-trash"></i></button>
             </div>
         </div>
     `).join('');
@@ -166,6 +162,7 @@ function openAddKarte() {
     document.getElementById('karteNummerWarning').style.display = 'none';
     delete document.getElementById('karteNummerWarning').dataset.acknowledged;
     document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Neue Kundenkarte';
+    document.getElementById('karteModalDeleteBtn').style.display = 'none';
     document.getElementById('karteOverlay').classList.add('active');
     stopScan();
 }
@@ -181,6 +178,9 @@ function openEditKarte(id) {
     document.getElementById('karteNummerWarning').style.display = 'none';
     delete document.getElementById('karteNummerWarning').dataset.acknowledged;
     document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Karte bearbeiten';
+    const deleteBtn = document.getElementById('karteModalDeleteBtn');
+    deleteBtn.style.display = '';
+    deleteBtn.onclick = () => { closeKarteModal(); openDeleteConfirm(id); };
     document.getElementById('karteOverlay').classList.add('active');
     stopScan();
 }
@@ -347,32 +347,19 @@ function previewKarteValidation() {
 // -- Long-Press Handler --
 let longPressTimer = null;
 let longPressTriggered = false;
-let activeTileActions = null;
 
 function onKarteTileClick(e, id) {
     if (longPressTriggered) { longPressTriggered = false; return; }
-    if (activeTileActions) { hideAllTileActions(); return; }
     showBarcode(id);
-}
-
-function showTileActions(tileEl) {
-    hideAllTileActions();
-    const actions = tileEl.querySelector('.tile-actions');
-    if (actions) { actions.classList.add('visible'); activeTileActions = actions; }
-}
-
-function hideAllTileActions() {
-    if (activeTileActions) { activeTileActions.classList.remove('visible'); activeTileActions = null; }
 }
 
 document.addEventListener('pointerdown', e => {
     const tile = e.target.closest('.tile');
-    if (!tile) return;
-    if (e.target.closest('.tile-actions')) return;
+    if (!tile || !tile.dataset.id) return;
     longPressTimer = setTimeout(() => {
         longPressTimer = null;
         longPressTriggered = true;
-        showTileActions(tile);
+        openEditKarte(parseInt(tile.dataset.id));
     }, 500);
 });
 
@@ -390,13 +377,9 @@ document.addEventListener('pointercancel', () => {
     if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
 });
 
-document.addEventListener('pointerdown', e => {
-    if (activeTileActions && !e.target.closest('.tile-actions')) { hideAllTileActions(); }
-}, true);
-
 // Keyboard
 document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') { hideAllTileActions(); closeBarcodeOverlay(); closeKarteModal(); closeDeleteConfirm(); }
+    if (e.key === 'Escape') { closeBarcodeOverlay(); closeKarteModal(); closeDeleteConfirm(); }
 });
 
 if (!_redirecting) checkAuth(showApp);

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -215,9 +215,14 @@
                     <i class="bi bi-plus"></i> Weitere Zutat
                 </button>
             </div>
-            <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem">
-                <button class="btn btn-secondary" onclick="closeGerichtEdit()">Abbrechen</button>
-                <button class="btn btn-primary" onclick="saveGericht()"><i class="bi bi-check-lg"></i> Speichern</button>
+            <div style="display:flex;gap:0.5rem;justify-content:space-between;margin-top:1rem">
+                <button class="btn btn-danger" id="gerichtDeleteBtn" style="display:none">
+                    <i class="bi bi-trash"></i> Löschen
+                </button>
+                <div style="display:flex;gap:0.5rem;margin-left:auto">
+                    <button class="btn btn-secondary" onclick="closeGerichtEdit()">Abbrechen</button>
+                    <button class="btn btn-primary" onclick="saveGericht()"><i class="bi bi-check-lg"></i> Speichern</button>
+                </div>
             </div>
         </div>
     </div>

--- a/public/rezepte.js
+++ b/public/rezepte.js
@@ -307,10 +307,6 @@ async function loadGerichteList() {
     }
     body.innerHTML = `<div style="margin-bottom:0.75rem">${gerichteCache.map(g => `<div class="rezept-item" style="justify-content:space-between">
         <span onclick="openGerichtEdit(${g.id})" style="flex:1;cursor:pointer">${esc(g.name)}</span>
-        <div style="display:flex;gap:0.25rem">
-            <button class="dish-cart-btn" onclick="openGerichtEdit(${g.id})" title="Bearbeiten"><i class="bi bi-pencil"></i></button>
-            <button class="dish-cart-btn" onclick="deleteGericht(${g.id})" title="Löschen" style="color:var(--red-400)"><i class="bi bi-trash"></i></button>
-        </div>
     </div>`).join('')}</div>
     <button class="btn btn-primary" style="width:100%" onclick="openGerichtEdit()"><i class="bi bi-plus-lg"></i> Neues Gericht</button>`;
 }
@@ -318,15 +314,19 @@ async function loadGerichteList() {
 async function openGerichtEdit(id) {
     document.getElementById('gerichtEditId').value = id || '';
     document.getElementById('gerichtEditTitle').innerHTML = id ? '<i class="bi bi-book"></i> Gericht bearbeiten' : '<i class="bi bi-book"></i> Neues Gericht';
+    const deleteBtn = document.getElementById('gerichtDeleteBtn');
     if (id) {
         const res = await fetch(`/api/gerichte/${id}`);
         if (!res.ok) return;
         const data = await res.json();
         document.getElementById('gerichtEditName').value = data.name;
         renderGerichtZutaten(data.zutaten.length > 0 ? data.zutaten : [{ artikel: '', menge: 1, einheit: 'Stück' }]);
+        deleteBtn.style.display = '';
+        deleteBtn.onclick = () => { closeGerichtEdit(); deleteGericht(id); };
     } else {
         document.getElementById('gerichtEditName').value = '';
         renderGerichtZutaten([{ artikel: '', menge: 1, einheit: 'Stück' }]);
+        deleteBtn.style.display = 'none';
     }
     document.getElementById('gerichtEditOverlay').classList.add('active');
     setTimeout(() => document.getElementById('gerichtEditName').focus(), 200);

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -148,9 +148,14 @@
                     <i class="bi bi-plus"></i> Weitere Zutat
                 </button>
             </div>
-            <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem">
-                <button class="btn btn-secondary" onclick="closeGerichtEdit()">Abbrechen</button>
-                <button class="btn btn-primary" onclick="saveGericht()"><i class="bi bi-check-lg"></i> Speichern</button>
+            <div style="display:flex;gap:0.5rem;justify-content:space-between;margin-top:1rem">
+                <button class="btn btn-danger" id="gerichtDeleteBtn" style="display:none">
+                    <i class="bi bi-trash"></i> Löschen
+                </button>
+                <div style="display:flex;gap:0.5rem;margin-left:auto">
+                    <button class="btn btn-secondary" onclick="closeGerichtEdit()">Abbrechen</button>
+                    <button class="btn btn-primary" onclick="saveGericht()"><i class="bi bi-check-lg"></i> Speichern</button>
+                </div>
             </div>
         </div>
     </div>

--- a/public/wochenplan.js
+++ b/public/wochenplan.js
@@ -587,10 +587,6 @@ async function loadGerichteList() {
         <div style="margin-bottom:0.75rem">
             ${gerichteCache.map(g => `<div class="rezept-item" style="justify-content:space-between">
                 <span onclick="openGerichtEdit(${g.id})" style="flex:1;cursor:pointer">${esc(g.name)}</span>
-                <div style="display:flex;gap:0.25rem">
-                    <button class="dish-cart-btn" onclick="openGerichtEdit(${g.id})" title="Bearbeiten"><i class="bi bi-pencil"></i></button>
-                    <button class="dish-cart-btn" onclick="deleteGericht(${g.id})" title="Löschen" style="color:var(--red-400)"><i class="bi bi-trash"></i></button>
-                </div>
             </div>`).join('')}
         </div>
         <button class="btn btn-primary" style="width:100%" onclick="openGerichtEdit()">
@@ -604,15 +600,19 @@ async function openGerichtEdit(id) {
         ? '<i class="bi bi-book"></i> Gericht bearbeiten'
         : '<i class="bi bi-book"></i> Neues Gericht';
 
+    const deleteBtn = document.getElementById('gerichtDeleteBtn');
     if (id) {
         const res = await fetch(`/api/gerichte/${id}`);
         if (!res.ok) return;
         const data = await res.json();
         document.getElementById('gerichtEditName').value = data.name;
         renderGerichtZutaten(data.zutaten.length > 0 ? data.zutaten : [{ artikel: '', menge: 1, einheit: 'Stück' }]);
+        deleteBtn.style.display = '';
+        deleteBtn.onclick = () => { closeGerichtEdit(); deleteGericht(id); };
     } else {
         document.getElementById('gerichtEditName').value = '';
         renderGerichtZutaten([{ artikel: '', menge: 1, einheit: 'Stück' }]);
+        deleteBtn.style.display = 'none';
     }
     document.getElementById('gerichtEditOverlay').classList.add('active');
     setTimeout(() => document.getElementById('gerichtEditName').focus(), 200);


### PR DESCRIPTION
## Summary
- Remove edit/delete buttons from all tiles (shopping list, customer cards, recipes, meal plan)
- Long-press on tiles now directly opens the edit modal instead of showing floating action buttons
- Delete button is shown inside the edit modal (only when editing existing items, not on create)

## Test plan
- [ ] Shopping list: tap tile → toggles purchased; long-press → opens edit modal with delete button
- [ ] Customer cards: tap tile → shows barcode; long-press → opens edit modal with delete button
- [ ] Recipes/Meal plan: click dish name → opens edit modal with delete button; no inline buttons shown
- [ ] Creating new items: verify delete button is hidden in all create modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)