### PR TITLE
fix: store and display barcodes in their original format

### DIFF
--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -140,6 +140,18 @@
             <div id="karteNummerWarning" style="display:none;color:var(--yellow-600,#ca8a04);font-size:0.75rem;font-weight:500;margin-top:0.25rem;margin-bottom:0.5rem">
                 <i class="bi bi-exclamation-triangle"></i> <span id="karteNummerWarningText"></span>
             </div>
+            <div style="margin-bottom:0.75rem">
+                <label for="karteBarcodeFormat">Barcode-Format</label>
+                <select id="karteBarcodeFormat" style="width:100%;padding:0.5rem;border:1px solid var(--gray-200);border-radius:var(--radius-sm);font-size:0.85rem;background:var(--white);color:var(--gray-700)">
+                    <option value="">Automatisch (CODE128)</option>
+                    <option value="EAN13">EAN-13</option>
+                    <option value="EAN8">EAN-8</option>
+                    <option value="CODE128">CODE128</option>
+                    <option value="CODE39">CODE39</option>
+                    <option value="ITF">ITF</option>
+                </select>
+                <div style="font-size:0.7rem;color:var(--gray-400);margin-top:0.25rem">Wird beim Scannen automatisch erkannt</div>
+            </div>
             <div style="margin-bottom:1rem">
                 <label for="karteNotiz">Notiz (optional)</label>
                 <input type="text" id="karteNotiz" placeholder="z.B. Familie" maxlength="500">

--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -2,6 +2,21 @@ let karten = [];
 let deleteTargetId = null;
 let html5QrScanner = null;
 let logoOverrides = {};
+let scannedBarcodeFormat = null;
+
+// Maps html5-qrcode format names to JsBarcode format names
+const BARCODE_FORMAT_MAP = {
+    'QR_CODE': 'QR_CODE',
+    'EAN_13': 'EAN13',
+    'EAN_8': 'EAN8',
+    'CODE_128': 'CODE128',
+    'CODE_39': 'CODE39',
+    'ITF': 'ITF'
+};
+
+function mapScanFormatToJsBarcode(formatName) {
+    return BARCODE_FORMAT_MAP[formatName] || 'CODE128';
+}
 
 function showApp() {
     showAppBase();
@@ -129,21 +144,38 @@ function showBarcode(id) {
     notizEl.textContent = k.notiz || '';
     notizEl.style.display = k.notiz ? '' : 'none';
 
-    // Generate barcode
+    // Generate barcode in the correct format
     const svg = document.getElementById('barcodeDisplay');
     svg.style.display = '';
     try {
         const cleanNum = k.kartennummer.replace(/\s/g, '');
-        JsBarcode('#barcodeDisplay', cleanNum, {
-            format: 'CODE128',
-            width: 2,
-            height: 80,
-            displayValue: false,
-            margin: 0,
-            background: '#ffffff'
-        });
+        const format = k.barcodeFormat || 'CODE128';
+        if (format === 'QR_CODE') {
+            svg.style.display = 'none';
+        } else {
+            JsBarcode('#barcodeDisplay', cleanNum, {
+                format: format,
+                width: 2,
+                height: 80,
+                displayValue: false,
+                margin: 0,
+                background: '#ffffff'
+            });
+        }
     } catch (e) {
-        svg.style.display = 'none';
+        try {
+            const cleanNum = k.kartennummer.replace(/\s/g, '');
+            JsBarcode('#barcodeDisplay', cleanNum, {
+                format: 'CODE128',
+                width: 2,
+                height: 80,
+                displayValue: false,
+                margin: 0,
+                background: '#ffffff'
+            });
+        } catch (e2) {
+            svg.style.display = 'none';
+        }
     }
 
     overlay.classList.add('active');
@@ -163,6 +195,9 @@ function openAddKarte() {
     delete document.getElementById('karteNummerWarning').dataset.acknowledged;
     document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Neue Kundenkarte';
     document.getElementById('karteModalDeleteBtn').style.display = 'none';
+    scannedBarcodeFormat = null;
+    const formatSelect = document.getElementById('karteBarcodeFormat');
+    if (formatSelect) formatSelect.value = '';
     document.getElementById('karteOverlay').classList.add('active');
     stopScan();
 }
@@ -178,6 +213,9 @@ function openEditKarte(id) {
     document.getElementById('karteNummerWarning').style.display = 'none';
     delete document.getElementById('karteNummerWarning').dataset.acknowledged;
     document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Karte bearbeiten';
+    scannedBarcodeFormat = k.barcodeFormat || null;
+    const formatSelect = document.getElementById('karteBarcodeFormat');
+    if (formatSelect) formatSelect.value = k.barcodeFormat || '';
     const deleteBtn = document.getElementById('karteModalDeleteBtn');
     deleteBtn.style.display = '';
     deleteBtn.onclick = () => { closeKarteModal(); openDeleteConfirm(id); };
@@ -211,8 +249,12 @@ function startScan() {
             Html5QrcodeSupportedFormats.ITF,
             Html5QrcodeSupportedFormats.QR_CODE
         ]},
-        (decodedText) => {
+        (decodedText, decodedResult) => {
             document.getElementById('karteNummer').value = decodedText;
+            const formatName = decodedResult?.result?.format?.formatName;
+            scannedBarcodeFormat = formatName ? mapScanFormatToJsBarcode(formatName) : 'CODE128';
+            const formatSelect = document.getElementById('karteBarcodeFormat');
+            if (formatSelect) formatSelect.value = scannedBarcodeFormat;
             toast('Barcode erkannt: ' + decodedText);
             stopScan();
         },
@@ -260,12 +302,15 @@ async function saveKarte() {
     }
     if (warnEl) { warnEl.style.display = 'none'; delete warnEl.dataset.acknowledged; }
 
+    const formatSelect = document.getElementById('karteBarcodeFormat');
+    const barcodeFormat = (formatSelect && formatSelect.value) || scannedBarcodeFormat || null;
+
     const method = id ? 'PUT' : 'POST';
     const url = id ? `/api/kundenkarten/${id}` : '/api/kundenkarten';
     const res = await fetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, kartennummer, notiz })
+        body: JSON.stringify({ name, kartennummer, notiz, barcodeFormat })
     });
 
     if (res.ok) {

--- a/src/controllers/kundenkartenController.js
+++ b/src/controllers/kundenkartenController.js
@@ -9,12 +9,12 @@ async function getAll(req, res) {
     let result;
     if (hid != null) {
       result = await db.request().input('hid', sql.Int, hid)
-        .query('SELECT Id, Name, Kartennummer, Notiz, ErstelltAm FROM Kundenkarte WHERE HaushaltId=@hid ORDER BY Name');
+        .query('SELECT Id, Name, Kartennummer, Notiz, BarcodeFormat, ErstelltAm FROM Kundenkarte WHERE HaushaltId=@hid ORDER BY Name');
     } else {
       result = await db.request().input('uid', sql.Int, userId)
-        .query('SELECT Id, Name, Kartennummer, Notiz, ErstelltAm FROM Kundenkarte WHERE BenutzerId=@uid AND HaushaltId IS NULL ORDER BY Name');
+        .query('SELECT Id, Name, Kartennummer, Notiz, BarcodeFormat, ErstelltAm FROM Kundenkarte WHERE BenutzerId=@uid AND HaushaltId IS NULL ORDER BY Name');
     }
-    res.json(result.recordset.map(r => ({ id: r.Id, name: r.Name, kartennummer: r.Kartennummer, notiz: r.Notiz || '', erstelltAm: r.ErstelltAm })));
+    res.json(result.recordset.map(r => ({ id: r.Id, name: r.Name, kartennummer: r.Kartennummer, notiz: r.Notiz || '', barcodeFormat: r.BarcodeFormat || null, erstelltAm: r.ErstelltAm })));
   } catch (e) {
     console.error('Kundenkarten GET Fehler:', e);
     res.status(500).json({ error: 'Interner Fehler.' });
@@ -27,15 +27,16 @@ async function create(req, res) {
     const db = await getPool();
     if (!await canWrite(userId, db)) return res.status(403).json({ error: 'Keine Schreibrechte.' });
     const hid = await getHaushaltId(userId, db);
-    const { name, kartennummer, notiz } = req.body;
+    const { name, kartennummer, notiz, barcodeFormat } = req.body;
     if (!name || !kartennummer) return res.status(400).json({ error: 'Name und Kartennummer erforderlich.' });
     const result = await db.request()
       .input('name', sql.NVarChar, name.trim())
       .input('kartennummer', sql.NVarChar, kartennummer.trim())
       .input('notiz', sql.NVarChar, (notiz || '').trim() || null)
+      .input('barcodeFormat', sql.NVarChar, (barcodeFormat || '').trim() || null)
       .input('uid', sql.Int, userId)
       .input('hid', sql.Int, hid)
-      .query('INSERT INTO Kundenkarte (Name, Kartennummer, Notiz, BenutzerId, HaushaltId) OUTPUT INSERTED.Id, INSERTED.ErstelltAm VALUES (@name, @kartennummer, @notiz, @uid, @hid)');
+      .query('INSERT INTO Kundenkarte (Name, Kartennummer, Notiz, BarcodeFormat, BenutzerId, HaushaltId) OUTPUT INSERTED.Id, INSERTED.ErstelltAm VALUES (@name, @kartennummer, @notiz, @barcodeFormat, @uid, @hid)');
     const row = result.recordset[0];
     res.json({ id: row.Id, erstelltAm: row.ErstelltAm });
   } catch (e) {
@@ -51,7 +52,7 @@ async function update(req, res) {
     const db = await getPool();
     if (!await canWrite(userId, db)) return res.status(403).json({ error: 'Keine Schreibrechte.' });
     const hid = await getHaushaltId(userId, db);
-    const { name, kartennummer, notiz } = req.body;
+    const { name, kartennummer, notiz, barcodeFormat } = req.body;
     if (!name || !kartennummer) return res.status(400).json({ error: 'Name und Kartennummer erforderlich.' });
     const where = hid != null ? 'Id=@id AND HaushaltId=@hid' : 'Id=@id AND BenutzerId=@uid AND HaushaltId IS NULL';
     const result = await db.request()
@@ -59,9 +60,10 @@ async function update(req, res) {
       .input('name', sql.NVarChar, name.trim())
       .input('kartennummer', sql.NVarChar, kartennummer.trim())
       .input('notiz', sql.NVarChar, (notiz || '').trim() || null)
+      .input('barcodeFormat', sql.NVarChar, (barcodeFormat || '').trim() || null)
       .input('uid', sql.Int, userId)
       .input('hid', sql.Int, hid)
-      .query(`UPDATE Kundenkarte SET Name=@name, Kartennummer=@kartennummer, Notiz=@notiz WHERE ${where}`);
+      .query(`UPDATE Kundenkarte SET Name=@name, Kartennummer=@kartennummer, Notiz=@notiz, BarcodeFormat=@barcodeFormat WHERE ${where}`);
     if (result.rowsAffected[0] > 0) res.json({});
     else res.status(404).json({ error: 'Karte nicht gefunden.' });
   } catch (e) {

--- a/src/startup.js
+++ b/src/startup.js
@@ -171,6 +171,11 @@ async function startup() {
           LogoUrl NVARCHAR(1000) NULL
       )`);
 
+    // Ensure BarcodeFormat column on Kundenkarte (for existing databases)
+    await db.request().query(`
+      IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id=OBJECT_ID('Kundenkarte') AND name='BarcodeFormat')
+      ALTER TABLE Kundenkarte ADD BarcodeFormat NVARCHAR(20) NULL`);
+
     // Ensure HaushaltRolle column on Benutzer (for existing databases)
     await db.request().query(`
       IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id=OBJECT_ID('Benutzer') AND name='HaushaltRolle')


### PR DESCRIPTION
## Summary

- **Problem:** Customer cards (e.g. Coop Supercard) were not recognized at checkout because the app always rendered barcodes as CODE128 regardless of the original format (EAN-13, EAN-8, etc.)
- **Fix:** Detect and store the original barcode format during scanning, then render in the correct format when displaying the barcode overlay
- **Backwards compatible:** Existing cards without a stored format fall back to CODE128

## Changes

- **DB:** New `BarcodeFormat NVARCHAR(20)` column on `Kundenkarte` (`src/startup.js`)
- **API:** GET/POST/PUT endpoints updated to read/write `barcodeFormat` (`src/controllers/kundenkartenController.js`)
- **Frontend:** Scanner callback captures format via `decodedResult.result.format.formatName`, maps to JsBarcode format names, and renders accordingly (`public/kundenkarten.js`)
- **UI:** Format dropdown in add/edit modal, auto-filled on scan, manually adjustable (`public/kundenkarten.html`)

## Test plan

- [ ] Scan a Coop Supercard (EAN-13) — verify format is detected as EAN13
- [ ] Open barcode overlay — verify barcode renders in EAN-13 format (not CODE128)
- [ ] Present barcode at checkout — verify POS scanner recognizes it
- [ ] Check existing cards without format — should still render as CODE128 (fallback)
- [ ] Manually change format in dropdown — verify barcode updates on next view
- [ ] Add card manually without scanning — verify default CODE128 works

🤖 Generated with [Claude Code](https://claude.com/claude-code)