### PR TITLE
fix: replace __dirname with process.cwd() for esbuild compatibility

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -42,7 +42,7 @@ app.use(session({
 }));
 
 // Serve static files - assumes src/app.js, so public is at ../public
-app.use(express.static(path.join(__dirname, '../public')));
+app.use(express.static(path.join(process.cwd(), 'public')));
 
 // --- Health Endpoint ---
 app.get('/api/health', (req, res) => {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -4,7 +4,7 @@ const path = require('path');
 let config = {};
 try {
   // Try to load from project root
-  config = JSON.parse(fs.readFileSync(path.join(__dirname, '../../config.json'), 'utf8'));
+  config = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'config.json'), 'utf8'));
 } catch {
   // console.warn('config.json not found or invalid, using env vars / defaults');
 }

--- a/src/startup.js
+++ b/src/startup.js
@@ -206,7 +206,7 @@ async function startup() {
   } catch (err) {
     console.error('Startup error:', err);
     try {
-      const logPath = path.join(__dirname, '..', 'startup-error.txt');
+      const logPath = path.join(process.cwd(), 'startup-error.txt');
       fs.writeFileSync(logPath, `${new Date().toISOString()}\n${err.stack || err}`);
     } catch { /* ignore write errors */ }
   }


### PR DESCRIPTION
## Summary

- **Problem:** After the src/ refactoring (PR #188), the production server (IIS + iisnode) returns 404 for all requests
- **Root cause:** `__dirname` in `src/` files resolves to the source directory during development, but after esbuild bundles everything into `dist/server.js`, it resolves to the deployment root — making relative paths like `../public` and `../../config.json` point outside the deployment directory
- **Fix:** Replace `__dirname` with `process.cwd()` which always resolves from the working directory (project/deployment root)

## Changes

| File | Before | After |
|------|--------|-------|
| `src/app.js:45` | `path.join(__dirname, '../public')` | `path.join(process.cwd(), 'public')` |
| `src/config/config.js:7` | `path.join(__dirname, '../../config.json')` | `path.join(process.cwd(), 'config.json')` |
| `src/startup.js:209` | `path.join(__dirname, '..', 'startup-error.txt')` | `path.join(process.cwd(), 'startup-error.txt')` |

## Test plan

- [x] Syntax check passes on all 3 files
- [x] esbuild bundle succeeds (3.2mb)
- [ ] Deploy to production → website loads without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)