### PR TITLE
feat: add QR code rendering for customer cards

### DIFF
--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -20,6 +20,7 @@
     <!-- Barcode libraries -->
     <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.6/dist/JsBarcode.all.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
 </head>
 <body>
 
@@ -101,6 +102,7 @@
         <div id="barcodeKarteNotiz" style="font-size:0.85rem;color:rgba(255,255,255,0.6);margin-bottom:1.5rem"></div>
         <div style="background:#fff;border-radius:12px;padding:1.5rem 2rem;margin-bottom:1rem">
             <svg id="barcodeDisplay"></svg>
+            <canvas id="qrcodeDisplay" style="display:none"></canvas>
         </div>
         <div style="font-size:1.3rem;font-weight:700;letter-spacing:0.1em;color:#fff;font-family:monospace;margin-bottom:2rem" id="barcodeKarteNummer"></div>
         <button class="btn btn-secondary" onclick="closeBarcodeOverlay()" style="color:#fff;border-color:rgba(255,255,255,0.3)">
@@ -149,6 +151,7 @@
                     <option value="CODE128">CODE128</option>
                     <option value="CODE39">CODE39</option>
                     <option value="ITF">ITF</option>
+                    <option value="QR_CODE">QR-Code</option>
                 </select>
                 <div style="font-size:0.7rem;color:var(--gray-400);margin-top:0.25rem">Wird beim Scannen automatisch erkannt</div>
             </div>

--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -144,15 +144,42 @@ function showBarcode(id) {
     notizEl.textContent = k.notiz || '';
     notizEl.style.display = k.notiz ? '' : 'none';
 
-    // Generate barcode in the correct format
+    // Generate barcode or QR code in the correct format
     const svg = document.getElementById('barcodeDisplay');
-    svg.style.display = '';
-    try {
-        const cleanNum = k.kartennummer.replace(/\s/g, '');
-        const format = k.barcodeFormat || 'CODE128';
-        if (format === 'QR_CODE') {
-            svg.style.display = 'none';
-        } else {
+    const qrCanvas = document.getElementById('qrcodeDisplay');
+    const cleanNum = k.kartennummer.replace(/\s/g, '');
+    const format = k.barcodeFormat || 'CODE128';
+
+    if (format === 'QR_CODE') {
+        svg.style.display = 'none';
+        qrCanvas.style.display = '';
+        try {
+            const qr = qrcode(0, 'M');
+            qr.addData(cleanNum);
+            qr.make();
+            const moduleCount = qr.getModuleCount();
+            const cellSize = Math.max(4, Math.floor(200 / moduleCount));
+            const size = moduleCount * cellSize;
+            qrCanvas.width = size;
+            qrCanvas.height = size;
+            const ctx = qrCanvas.getContext('2d');
+            ctx.fillStyle = '#ffffff';
+            ctx.fillRect(0, 0, size, size);
+            ctx.fillStyle = '#000000';
+            for (let row = 0; row < moduleCount; row++) {
+                for (let col = 0; col < moduleCount; col++) {
+                    if (qr.isDark(row, col)) {
+                        ctx.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
+                    }
+                }
+            }
+        } catch (e) {
+            qrCanvas.style.display = 'none';
+        }
+    } else {
+        qrCanvas.style.display = 'none';
+        svg.style.display = '';
+        try {
             JsBarcode('#barcodeDisplay', cleanNum, {
                 format: format,
                 width: 2,
@@ -161,20 +188,19 @@ function showBarcode(id) {
                 margin: 0,
                 background: '#ffffff'
             });
-        }
-    } catch (e) {
-        try {
-            const cleanNum = k.kartennummer.replace(/\s/g, '');
-            JsBarcode('#barcodeDisplay', cleanNum, {
-                format: 'CODE128',
-                width: 2,
-                height: 80,
-                displayValue: false,
-                margin: 0,
-                background: '#ffffff'
-            });
-        } catch (e2) {
-            svg.style.display = 'none';
+        } catch (e) {
+            try {
+                JsBarcode('#barcodeDisplay', cleanNum, {
+                    format: 'CODE128',
+                    width: 2,
+                    height: 80,
+                    displayValue: false,
+                    margin: 0,
+                    background: '#ffffff'
+                });
+            } catch (e2) {
+                svg.style.display = 'none';
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **Problem:** The barcode scanner detected QR codes but the overlay could not display them — JsBarcode only supports 1D barcodes. Customer cards with QR codes showed a blank overlay at checkout.
- **Fix:** Added `qrcode-generator` library to render QR codes on a canvas element, switching between canvas (QR) and SVG (1D barcode) based on stored format.

## Changes

- **Library:** Added `qrcode-generator@1.4.4` via CDN (~10KB)
- **Overlay:** New `<canvas id="qrcodeDisplay">` alongside existing `<svg id="barcodeDisplay">`
- **Rendering:** `showBarcode()` now renders QR codes using canvas when format is `QR_CODE`, otherwise uses JsBarcode SVG as before
- **Dropdown:** Added "QR-Code" as selectable barcode format option

## Test plan

- [ ] Create card with format "QR-Code" and a number → overlay shows QR code
- [ ] Scan QR code from overlay with phone scanner → correct number decoded
- [ ] Existing 1D barcode cards render unchanged
- [ ] Scan a physical QR code card → format auto-detected as QR_CODE, renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)