### PR TITLE
refactor: remove barcode format dropdown, use auto-detection only

### DIFF
--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -142,19 +142,6 @@
             <div id="karteNummerWarning" style="display:none;color:var(--yellow-600,#ca8a04);font-size:0.75rem;font-weight:500;margin-top:0.25rem;margin-bottom:0.5rem">
                 <i class="bi bi-exclamation-triangle"></i> <span id="karteNummerWarningText"></span>
             </div>
-            <div style="margin-bottom:0.75rem">
-                <label for="karteBarcodeFormat">Barcode-Format</label>
-                <select id="karteBarcodeFormat" style="width:100%;padding:0.5rem;border:1px solid var(--gray-200);border-radius:var(--radius-sm);font-size:0.85rem;background:var(--white);color:var(--gray-700)">
-                    <option value="">Automatisch (CODE128)</option>
-                    <option value="EAN13">EAN-13</option>
-                    <option value="EAN8">EAN-8</option>
-                    <option value="CODE128">CODE128</option>
-                    <option value="CODE39">CODE39</option>
-                    <option value="ITF">ITF</option>
-                    <option value="QR_CODE">QR-Code</option>
-                </select>
-                <div style="font-size:0.7rem;color:var(--gray-400);margin-top:0.25rem">Wird beim Scannen automatisch erkannt</div>
-            </div>
             <div style="margin-bottom:1rem">
                 <label for="karteNotiz">Notiz (optional)</label>
                 <input type="text" id="karteNotiz" placeholder="z.B. Familie" maxlength="500">

--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -222,8 +222,6 @@ function openAddKarte() {
     document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Neue Kundenkarte';
     document.getElementById('karteModalDeleteBtn').style.display = 'none';
     scannedBarcodeFormat = null;
-    const formatSelect = document.getElementById('karteBarcodeFormat');
-    if (formatSelect) formatSelect.value = '';
     document.getElementById('karteOverlay').classList.add('active');
     stopScan();
 }
@@ -240,8 +238,6 @@ function openEditKarte(id) {
     delete document.getElementById('karteNummerWarning').dataset.acknowledged;
     document.getElementById('karteModalTitle').innerHTML = '<i class="bi bi-credit-card"></i> Karte bearbeiten';
     scannedBarcodeFormat = k.barcodeFormat || null;
-    const formatSelect = document.getElementById('karteBarcodeFormat');
-    if (formatSelect) formatSelect.value = k.barcodeFormat || '';
     const deleteBtn = document.getElementById('karteModalDeleteBtn');
     deleteBtn.style.display = '';
     deleteBtn.onclick = () => { closeKarteModal(); openDeleteConfirm(id); };
@@ -279,8 +275,6 @@ function startScan() {
             document.getElementById('karteNummer').value = decodedText;
             const formatName = decodedResult?.result?.format?.formatName;
             scannedBarcodeFormat = formatName ? mapScanFormatToJsBarcode(formatName) : 'CODE128';
-            const formatSelect = document.getElementById('karteBarcodeFormat');
-            if (formatSelect) formatSelect.value = scannedBarcodeFormat;
             toast('Barcode erkannt: ' + decodedText);
             stopScan();
         },
@@ -328,8 +322,7 @@ async function saveKarte() {
     }
     if (warnEl) { warnEl.style.display = 'none'; delete warnEl.dataset.acknowledged; }
 
-    const formatSelect = document.getElementById('karteBarcodeFormat');
-    const barcodeFormat = (formatSelect && formatSelect.value) || scannedBarcodeFormat || null;
+    const barcodeFormat = scannedBarcodeFormat || null;
 
     const method = id ? 'PUT' : 'POST';
     const url = id ? `/api/kundenkarten/${id}` : '/api/kundenkarten';


### PR DESCRIPTION
## Summary

- **Change:** Removed the manual barcode format dropdown from the customer card add/edit modal
- **Reason:** The format should be determined automatically by the scanner — no user interaction needed
- **Behavior:** Format is still stored in the DB when auto-detected during scanning; manual entries default to CODE128

## Test plan

- [ ] Add card by scanning → format auto-detected and saved (no dropdown visible)
- [ ] Add card manually → no dropdown shown, defaults to CODE128
- [ ] Edit existing card → no dropdown shown, stored format preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)