### PR TITLE
fix: make scanner qrbox square for QR code support

### DIFF
--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -263,7 +263,7 @@ function startScan() {
     html5QrScanner = new Html5Qrcode('scannerView');
     html5QrScanner.start(
         { facingMode: 'environment' },
-        { fps: 10, qrbox: { width: 280, height: 100 }, formatsToSupport: [
+        { fps: 10, qrbox: { width: 250, height: 250 }, formatsToSupport: [
             Html5QrcodeSupportedFormats.CODE_128,
             Html5QrcodeSupportedFormats.EAN_13,
             Html5QrcodeSupportedFormats.EAN_8,


### PR DESCRIPTION
## Summary

- **Problem:** The scanner area (`qrbox`) was `280x100` — a narrow rectangle that could not fit square QR codes, making them impossible to scan
- **Fix:** Changed to `250x250` (square) which works for both 1D barcodes and QR codes

## Test plan

- [ ] Open scanner → scan area is now square
- [ ] Scan a 1D barcode → still recognized correctly
- [ ] Scan a QR code → now recognized

🤖 Generated with [Claude Code](https://claude.com/claude-code)