### PR TITLE
debug: show detected barcode format in toast

### DIFF
--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -275,7 +275,7 @@ function startScan() {
             document.getElementById('karteNummer').value = decodedText;
             const formatName = decodedResult?.result?.format?.formatName;
             scannedBarcodeFormat = formatName ? mapScanFormatToJsBarcode(formatName) : 'CODE128';
-            toast('Barcode erkannt: ' + decodedText);
+            toast('Erkannt (' + (formatName || 'unbekannt') + '): ' + decodedText);
             stopScan();
         },
         () => {}


### PR DESCRIPTION
## Summary

Temporary debug change: the toast after scanning now shows the detected format name (e.g. "Erkannt (QR_CODE): ...") to diagnose why QR codes are saved/displayed as 1D barcodes.

## To test

1. Scan a QR code → check what format the toast shows
2. Report back the format name shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)