### PR TITLE
fix: support Data Matrix and other 2D codes for customer cards

### DIFF
--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -7,6 +7,9 @@ let scannedBarcodeFormat = null;
 // Maps html5-qrcode format names to JsBarcode format names
 const BARCODE_FORMAT_MAP = {
     'QR_CODE': 'QR_CODE',
+    'DATA_MATRIX': 'DATA_MATRIX',
+    'AZTEC': 'AZTEC',
+    'PDF_417': 'PDF_417',
     'EAN_13': 'EAN13',
     'EAN_8': 'EAN8',
     'CODE_128': 'CODE128',
@@ -150,7 +153,8 @@ function showBarcode(id) {
     const cleanNum = k.kartennummer.replace(/\s/g, '');
     const format = k.barcodeFormat || 'CODE128';
 
-    if (format === 'QR_CODE') {
+    const is2D = ['QR_CODE', 'DATA_MATRIX', 'AZTEC', 'PDF_417'].includes(format);
+    if (is2D) {
         svg.style.display = 'none';
         qrCanvas.style.display = '';
         try {
@@ -275,7 +279,7 @@ function startScan() {
             document.getElementById('karteNummer').value = decodedText;
             const formatName = decodedResult?.result?.format?.formatName;
             scannedBarcodeFormat = formatName ? mapScanFormatToJsBarcode(formatName) : 'CODE128';
-            toast('Erkannt (' + (formatName || 'unbekannt') + '): ' + decodedText);
+            toast('Barcode erkannt: ' + decodedText);
             stopScan();
         },
         () => {}


### PR DESCRIPTION
## Summary

- **Problem:** Coop Supercard and similar cards use **Data Matrix** (not QR Code). The scanner detected them but mapped `DATA_MATRIX` to the `CODE128` fallback, rendering them as unreadable 1D barcodes.
- **Fix:** Added `DATA_MATRIX`, `AZTEC`, and `PDF_417` to the format map and 2D rendering path so they display as scannable 2D codes.
- Also removes the debug toast from PR #200.

## Changes

- `BARCODE_FORMAT_MAP`: Added `DATA_MATRIX`, `AZTEC`, `PDF_417` entries
- `showBarcode()`: 2D check now includes all 2D formats, not just `QR_CODE`
- Reverted debug toast back to standard message

## Test plan

- [ ] Scan a Coop Supercard (Data Matrix) → format detected as DATA_MATRIX
- [ ] View card in overlay → renders as 2D code (not 1D barcode)
- [ ] Scan 2D code from overlay with phone → correct number decoded
- [ ] Existing 1D barcode cards still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)