### PR TITLE
fix: close dialog on save and hide card number in overlay

### DIFF
--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -104,7 +104,7 @@
             <svg id="barcodeDisplay"></svg>
             <canvas id="qrcodeDisplay" style="display:none"></canvas>
         </div>
-        <div style="font-size:1.3rem;font-weight:700;letter-spacing:0.1em;color:#fff;font-family:monospace;margin-bottom:2rem" id="barcodeKarteNummer"></div>
+        <div id="barcodeKarteNummer" style="display:none"></div>
         <button class="btn btn-secondary" onclick="closeBarcodeOverlay()" style="color:#fff;border-color:rgba(255,255,255,0.3)">
             <i class="bi bi-x-lg"></i> Schliessen
         </button>

--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -314,17 +314,7 @@ async function saveKarte() {
     }
 
     const warnEl = document.getElementById('karteNummerWarning');
-    const warnTextEl = document.getElementById('karteNummerWarningText');
-    const warnings = validateKartennummer(kartennummer);
-    if (warnings.length > 0) {
-        warnTextEl.textContent = warnings.join(' ');
-        warnEl.style.display = '';
-        if (!warnEl.dataset.acknowledged) {
-            warnEl.dataset.acknowledged = '1';
-            return;
-        }
-    }
-    if (warnEl) { warnEl.style.display = 'none'; delete warnEl.dataset.acknowledged; }
+    if (warnEl) { warnEl.style.display = 'none'; }
 
     const barcodeFormat = scannedBarcodeFormat || null;
 


### PR DESCRIPTION
## Summary

- **Dialog stays open:** The validation warning blocked the first save click, requiring a second click to confirm. Especially problematic for scanned QR/Data Matrix codes with non-numeric characters. Removed the blocking validation so save works immediately.
- **Card number visible:** The card number was displayed below the barcode in the overlay. Hidden it since it should not be visible at checkout.

## Test plan

- [ ] Scan a card and click save → dialog closes immediately on first click
- [ ] Open card overlay → no card number shown below barcode
- [ ] Manually enter a card and save → dialog closes on first click

🤖 Generated with [Claude Code](https://claude.com/claude-code)