### PR TITLE
style: rename HaushaltPLUS to Haushalt⁺ with superscript plus

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Haushalt+">
-    <meta name="description" content="Über die HaushaltPLUS-App">
+    <meta name="description" content="Über die Haushalt⁺-App">
     <title>Haushalt+</title>
 
     <!-- PWA -->
@@ -139,7 +139,7 @@
         <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite" aria-label="Startseite"><i class="bi bi-house-door-fill"></i></a>
     </div>
     <div class="navbar-center">
-        <span class="navbar-brand">HaushaltPLUS</span>
+        <span class="navbar-brand">Haushalt<sup>+</sup></span>
     </div>
     <div class="navbar-right">
         <a href="index.html" class="btn-nav btn-nav-icon" title="Zurück">
@@ -153,15 +153,15 @@
     <!-- Hero -->
     <div class="about-hero">
         <i class="bi bi-cart3"></i>
-        <h1>HaushaltPLUS</h1>
+        <h1>Haushalt<sup>+</sup></h1>
         <p>Deine smarte Einkaufs- und Essensplanungs-App</p>
     </div>
 
     <!-- Beschreibung -->
     <div class="about-section">
-        <h2><i class="bi bi-info-circle"></i> Was ist HaushaltPLUS?</h2>
+        <h2><i class="bi bi-info-circle"></i> Was ist Haushalt<sup>+</sup>?</h2>
         <p>
-            HaushaltPLUS ist eine Progressive Web App (PWA) für die gemeinsame Einkaufsplanung
+            Haushalt⁺ ist eine Progressive Web App (PWA) für die gemeinsame Einkaufsplanung
             im Haushalt. Die App bietet weit mehr als eine einfache Liste: sie kombiniert
             Einkaufsverwaltung, Wochenplanung, Rezeptverwaltung und aktuelle Aktionen
             von Schweizer Detailhändlern in einer einzigen Anwendung.

--- a/public/admin.html
+++ b/public/admin.html
@@ -32,7 +32,7 @@
         <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite" aria-label="Startseite"><i class="bi bi-house-door-fill"></i></a>
     </div>
     <div class="navbar-center">
-        <span class="navbar-brand">HaushaltPLUS</span>
+        <span class="navbar-brand">Haushalt<sup>+</sup></span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Haushalt+">
-    <meta name="description" content="HaushaltPLUS – Einkaufsliste, Wochenplan, Rezepte und mehr">
+    <meta name="description" content="Haushalt⁺ – Einkaufsliste, Wochenplan, Rezepte und mehr">
     <title>Haushalt+</title>
 
     <!-- PWA -->
@@ -29,7 +29,7 @@
         <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite" aria-label="Startseite"><i class="bi bi-house-door-fill"></i></a>
     </div>
     <div class="navbar-center">
-        <span class="navbar-brand">HaushaltPLUS</span>
+        <span class="navbar-brand">Haushalt<sup>+</sup></span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">
@@ -267,7 +267,7 @@
     <div class="login-card">
         <div class="login-header">
             <i class="bi bi-cart3" style="font-size:2.5rem;color:var(--green-600)"></i>
-            <h1 style="font-size:1.5rem;margin-top:0.5rem">HaushaltPLUS</h1>
+            <h1 style="font-size:1.5rem;margin-top:0.5rem">Haushalt<sup>+</sup></h1>
             <p style="color:var(--gray-500);font-size:0.85rem;margin-top:0.25rem">Anmelden</p>
         </div>
         <form onsubmit="submitAuth(event)">

--- a/public/kundenkarten.html
+++ b/public/kundenkarten.html
@@ -29,7 +29,7 @@
         <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite" aria-label="Startseite"><i class="bi bi-house-door-fill"></i></a>
     </div>
     <div class="navbar-center">
-        <span class="navbar-brand">HaushaltPLUS</span>
+        <span class="navbar-brand">Haushalt<sup>+</sup></span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-    "name": "HaushaltPLUS",
+    "name": "Haushalt⁺",
     "short_name": "Haushalt+",
-    "description": "HaushaltPLUS – Einkaufsliste, Wochenplan, Rezepte und mehr",
+    "description": "Haushalt⁺ – Einkaufsliste, Wochenplan, Rezepte und mehr",
     "start_url": "./index.html",
     "display": "standalone",
     "background_color": "#f3f4f6",

--- a/public/profil.html
+++ b/public/profil.html
@@ -24,7 +24,7 @@
         <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite" aria-label="Startseite"><i class="bi bi-house-door-fill"></i></a>
     </div>
     <div class="navbar-center">
-        <span class="navbar-brand">HaushaltPLUS</span>
+        <span class="navbar-brand">Haushalt<sup>+</sup></span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">

--- a/public/rezepte.html
+++ b/public/rezepte.html
@@ -79,7 +79,7 @@
         <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite" aria-label="Startseite"><i class="bi bi-house-door-fill"></i></a>
     </div>
     <div class="navbar-center">
-        <span class="navbar-brand">HaushaltPLUS</span>
+        <span class="navbar-brand">Haushalt<sup>+</sup></span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">

--- a/public/tankrabatte.html
+++ b/public/tankrabatte.html
@@ -19,7 +19,7 @@
         <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite" aria-label="Startseite"><i class="bi bi-house-door-fill"></i></a>
     </div>
     <div class="navbar-center">
-        <span class="navbar-brand">HaushaltPLUS</span>
+        <span class="navbar-brand">Haushalt<sup>+</sup></span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">

--- a/public/wochenplan.html
+++ b/public/wochenplan.html
@@ -19,7 +19,7 @@
         <a href="index.html" class="btn-nav btn-nav-icon" title="Startseite" aria-label="Startseite"><i class="bi bi-house-door-fill"></i></a>
     </div>
     <div class="navbar-center">
-        <span class="navbar-brand">HaushaltPLUS</span>
+        <span class="navbar-brand">Haushalt<sup>+</sup></span>
     </div>
     <div class="navbar-right">
         <div class="nav-dropdown" id="navDropdown">

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -89,8 +89,8 @@ async function activate(req, res) {
       .input('token', sql.NVarChar, token)
       .query('UPDATE Benutzer SET EmailBestaetigt=1, AktivierungsToken=NULL WHERE AktivierungsToken=@token AND EmailBestaetigt=0');
 
-    const htmlOk = '<html><body style="font-family:sans-serif;text-align:center;padding:3rem"><h2 style="color:#22c55e">&#10003; E-Mail bestätigt!</h2><p>Dein Konto ist jetzt aktiv. Du kannst dich anmelden.</p><a href="/">Zur HaushaltPLUS</a></body></html>';
-    const htmlFail = '<html><body style="font-family:sans-serif;text-align:center;padding:3rem"><h2 style="color:#ef4444">Link ungültig</h2><p>Dieser Aktivierungslink ist ungültig oder wurde bereits verwendet.</p><a href="/">Zur HaushaltPLUS</a></body></html>';
+    const htmlOk = '<html><body style="font-family:sans-serif;text-align:center;padding:3rem"><h2 style="color:#22c55e">&#10003; E-Mail bestätigt!</h2><p>Dein Konto ist jetzt aktiv. Du kannst dich anmelden.</p><a href="/">Zur Haushalt⁺</a></body></html>';
+    const htmlFail = '<html><body style="font-family:sans-serif;text-align:center;padding:3rem"><h2 style="color:#ef4444">Link ungültig</h2><p>Dieser Aktivierungslink ist ungültig oder wurde bereits verwendet.</p><a href="/">Zur Haushalt⁺</a></body></html>';
 
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.send(result.rowsAffected[0] > 0 ? htmlOk : htmlFail);

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -7,7 +7,7 @@ async function sendActivationEmail(email, username, token, req) {
   const user = config.smtp.user || '';
   const pass = config.smtp.password || '';
   const fromAddr = config.smtp.from || user;
-  const fromName = config.smtp.fromName || 'HaushaltPLUS';
+  const fromName = config.smtp.fromName || 'Haushalt⁺';
 
   const baseUrl = `${req.protocol}://${req.get('host')}`;
   const link = `${baseUrl}/api/auth/aktivieren?token=${encodeURIComponent(token)}`;
@@ -21,7 +21,7 @@ ${link}
 Falls du dich nicht registriert hast, kannst du diese E-Mail ignorieren.
 
 Viele Grüsse
-HaushaltPLUS`;
+Haushalt⁺`;
 
   const transporter = nodemailer.createTransport({
     host, port,
@@ -32,7 +32,7 @@ HaushaltPLUS`;
   await transporter.sendMail({
     from: `"${fromName}" <${fromAddr}>`,
     to: email,
-    subject: 'HaushaltPLUS – E-Mail bestätigen',
+    subject: 'Haushalt⁺ – E-Mail bestätigen',
     text: body
   });
 }
@@ -43,7 +43,7 @@ async function sendResetEmail(email, username, token, req) {
   const user = config.smtp.user || '';
   const pass = config.smtp.password || '';
   const fromAddr = config.smtp.from || user;
-  const fromName = config.smtp.fromName || 'HaushaltPLUS';
+  const fromName = config.smtp.fromName || 'Haushalt⁺';
 
   const baseUrl = `${req.protocol}://${req.get('host')}`;
   const link = `${baseUrl}/reset.html?token=${encodeURIComponent(token)}`;
@@ -59,7 +59,7 @@ Der Link ist 1 Stunde gültig.
 Falls du dies nicht angefordert hast, kannst du diese E-Mail ignorieren.
 
 Viele Grüsse
-HaushaltPLUS`;
+Haushalt⁺`;
 
   const transporter = nodemailer.createTransport({
     host, port,
@@ -70,7 +70,7 @@ HaushaltPLUS`;
   await transporter.sendMail({
     from: `"${fromName}" <${fromAddr}>`,
     to: email,
-    subject: 'HaushaltPLUS – Passwort zurücksetzen',
+    subject: 'Haushalt⁺ – Passwort zurücksetzen',
     text: body
   });
 }


### PR DESCRIPTION
## Summary

- **Change:** Rebrand from "HaushaltPLUS" to "Haushalt⁺" with a superscript plus sign
- Uses `<sup>+</sup>` in HTML elements (navbar, headings, login)
- Uses Unicode `⁺` in plain text (meta descriptions, manifest, emails, auth pages)
- GitHub repository URL and technical identifiers (User-Agent, repo config) left unchanged

## Files changed (11)

- All HTML pages: navbar brand + any visible "HaushaltPLUS" text
- `manifest.json`: PWA name and description
- `src/utils/email.js`: email sender name, signatures, subjects
- `src/controllers/authController.js`: activation/error page links

## Test plan

- [ ] All pages show "Haushalt⁺" in navbar (with superscript)
- [ ] Login page title shows "Haushalt⁺"
- [ ] About page text uses "Haushalt⁺"
- [ ] PWA install prompt shows "Haushalt⁺"

🤖 Generated with [Claude Code](https://claude.com/claude-code)