### PR TITLE
fix(pwa): Service Worker Cache-Version bumpen und Bugfixes

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -5,6 +5,11 @@
     --primary-600: #3b82f6;
     --primary-700: #2563eb;
 
+    /* Legacy aliases for cached JS files */
+    --green-600: var(--primary-600);
+    --green-700: var(--primary-700);
+    --green-50: var(--primary-50);
+
     /* Status colors */
     --red-500: #ef4444;
     --red-50: rgba(239,68,68,0.08);

--- a/public/layout.js
+++ b/public/layout.js
@@ -120,13 +120,15 @@ function applyDarkThemeColor() {
     }
 }
 
-function injectBottomNav() {
+function injectBottomNav(extraLinks) {
     const page = location.pathname.split('/').pop() || 'index.html';
+    const allLinks = extraLinks ? SIDEBAR_LINKS.concat(extraLinks) : SIDEBAR_LINKS;
     const nav = document.createElement('nav');
     nav.className = 'bottom-nav';
+    nav.id = 'bottomNav';
     nav.setAttribute('role', 'navigation');
     nav.setAttribute('aria-label', 'Hauptnavigation');
-    nav.innerHTML = SIDEBAR_LINKS.map(l =>
+    nav.innerHTML = allLinks.map(l =>
         `<a href="${l.href}" class="bottom-nav-item${page === l.href ? ' active' : ''}"><i class="bi ${l.icon}"></i><span>${l.label}</span></a>`
     ).join('');
     document.body.appendChild(nav);
@@ -137,7 +139,7 @@ function initLayout(opts) {
     applyDarkThemeColor();
     injectNavbar(opts && opts.extraMenu);
     injectSidebar(opts && opts.extraSidebarLinks);
-    injectBottomNav();
+    injectBottomNav(opts && opts.extraSidebarLinks);
     injectLogin(opts && opts.loginIcon);
     injectToasts();
 }

--- a/public/shared.js
+++ b/public/shared.js
@@ -85,7 +85,7 @@ function showAppBase() {
     if (sidebar) sidebar.classList.remove('hidden');
     const logoutBtn = document.getElementById('logoutBtn');
     if (logoutBtn) logoutBtn.style.display = '';
-    // Show admin link in sidebar for admins
+    // Show admin link in sidebar and bottom nav for admins
     if (currentUser && currentUser.isAdmin) {
         const nav = document.querySelector('.sidebar-nav');
         if (nav && !document.getElementById('adminSidebarLink')) {
@@ -95,6 +95,16 @@ function showAppBase() {
             link.className = 'sidebar-link';
             link.innerHTML = '<i class="bi bi-shield-lock"></i> <span>Admin</span>';
             nav.appendChild(link);
+        }
+        const bottomNav = document.getElementById('bottomNav');
+        if (bottomNav && !document.getElementById('adminBottomLink')) {
+            const page = location.pathname.split('/').pop() || 'index.html';
+            const link = document.createElement('a');
+            link.id = 'adminBottomLink';
+            link.href = 'admin.html';
+            link.className = 'bottom-nav-item' + (page === 'admin.html' ? ' active' : '');
+            link.innerHTML = '<i class="bi bi-shield-lock"></i><span>Admin</span>';
+            bottomNav.appendChild(link);
         }
     }
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'haushalt-plus-v1';
+const CACHE_NAME = 'haushalt-plus-v2';
 const ASSETS = [
     './',
     './index.html',
@@ -16,6 +16,7 @@ const ASSETS = [
     './app.js',
     './shared.js',
     './layout.js',
+    './bugreport.js',
     './webauthn.js',
     './lib/simplewebauthn-browser.min.js',
     './rezepte.js',
@@ -26,8 +27,7 @@ const ASSETS = [
     './manifest.json',
     './icons/icon-192.svg',
     './icons/icon-512.svg',
-    'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css',
-    'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap'
+    'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css'
 ];
 
 // Install: cache all assets


### PR DESCRIPTION
- CACHE_NAME auf v2 gebumpt (erzwingt Re-Cache aller Assets)
- Google Fonts URL aus SW ASSETS entfernt (kann cache.addAll blockieren)
- bugreport.js zum SW Cache hinzugefügt (fehlte)
- --green-* Legacy-Aliase in CSS zurück als Fallback für gecachte JS-Dateien
- Admin-Link in Mobile Bottom Nav für Admin-User hinzugefügt
- Bottom Nav unterstützt jetzt extraSidebarLinks (z.B. Admin)

[NO-TICKET]