### PR TITLE
fix: Admin-Seite leer und Server-Startup-Crash beheben

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -198,7 +198,7 @@
 <script src="bugreport.js"></script>
 <script>initLayout({ loginIcon: 'bi-shield-lock', extraSidebarLinks: [{ href: 'admin.html', icon: 'bi-shield-lock', label: 'Admin' }] });</script>
 <script>
-let currentUser = null;
+currentUser = null;
 let users = [];
 
 async function checkAuth() {

--- a/src/startup.js
+++ b/src/startup.js
@@ -9,6 +9,10 @@ const adminPassword = config.adminPassword || '';
 async function startup() {
   try {
     const db = await getPool();
+    if (!db) {
+      console.warn('No database connection configured – skipping database initialization.');
+      return;
+    }
 
     // Ensure all base tables exist
     await db.request().query(`


### PR DESCRIPTION
## Summary
- **Admin-Seite leer**: `let currentUser` in `admin.html` Inline-Script kollidierte mit der gleichen Deklaration in `shared.js` (SyntaxError zerstörte den gesamten Script-Block → leere Seite). Fix: `let` → Reassignment.
- **Server-Startup-Crash**: `startup.js` crashte mit `TypeError: Cannot read properties of undefined (reading 'request')` wenn keine DB-Verbindung konfiguriert war. Fix: Null-Guard nach `getPool()`.

## Test plan
- [ ] Admin-Seite öffnen → Login und Inhalte werden korrekt angezeigt
- [ ] Server ohne DB-Config starten → saubere Warnung statt Crash
- [ ] Kundenkarten, Artikel-Kauf, Gekauft-Sektion mit DB-Verbindung testen

🤖 Generated with [Claude Code](https://claude.com/claude-code)