### PR TITLE
feat: Laden-Gruppen ein-/ausklappbar

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -559,6 +559,12 @@ input:focus, select:focus {
     color: var(--gray-400);
     transition: transform 0.15s;
 }
+.store-group-tiles {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 0.6rem;
+}
 .store-group-header:first-child {
     margin-top: 0;
 }
@@ -817,6 +823,7 @@ input:focus, select:focus {
     .btn-nav.desktop-only { display: none; }
     .tile-grid { grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 0.5rem; }
     .gekauft-grid.open { grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 0.5rem; }
+    .store-group-tiles { grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 0.5rem; }
     .tile { padding: 0.6rem 0.75rem; }
 
     /* Sidebar: collapsed on mobile */

--- a/public/app.js
+++ b/public/app.js
@@ -403,6 +403,16 @@ function renderTile(item) {
 }
 
 // -- Grouped rendering --
+let collapsedStoreGroups = {};
+
+function toggleStoreGroup(groupId) {
+    collapsedStoreGroups[groupId] = !collapsedStoreGroups[groupId];
+    const container = document.getElementById('store-group-' + groupId);
+    const arrow = document.querySelector(`.store-group-header[data-group="${groupId}"] .store-toggle`);
+    if (container) container.style.display = collapsedStoreGroups[groupId] ? 'none' : '';
+    if (arrow) arrow.style.transform = collapsedStoreGroups[groupId] ? 'rotate(-90deg)' : '';
+}
+
 function renderGrouped(list) {
     const groups = {};
     list.forEach(item => {
@@ -420,13 +430,18 @@ function renderGrouped(list) {
     let html = '';
     keys.forEach(key => {
         const storeName = key || 'Kein Laden';
+        const groupId = (key || '__none__').replace(/'/g, "\\'");
         const icon = `<i class="bi ${key ? 'bi-shop' : 'bi-question-circle'}"></i>`;
-        html += `<div class="store-group-header">
+        const collapsed = collapsedStoreGroups[groupId];
+        const arrowStyle = collapsed ? ' style="transform:rotate(-90deg)"' : '';
+        html += `<div class="store-group-header" data-group="${esc(groupId)}" onclick="toggleStoreGroup('${groupId}')">
+            <i class="bi bi-chevron-down store-toggle"${arrowStyle}></i>
             <span class="store-name">${icon} ${esc(storeName)}</span>
             <span class="store-count">${groups[key].length}</span>
             <div class="store-line"></div>
         </div>`;
-        html += groups[key].sort((a, b) => a.artikel.localeCompare(b.artikel)).map(item => renderTile(item)).join('');
+        const tilesHtml = groups[key].sort((a, b) => a.artikel.localeCompare(b.artikel)).map(item => renderTile(item)).join('');
+        html += `<div class="store-group-tiles" id="store-group-${esc(groupId)}"${collapsed ? ' style="display:none"' : ''}>${tilesHtml}</div>`;
     });
     return html;
 }


### PR DESCRIPTION
## Summary

- Laden-Gruppen in der Einkaufsliste sind jetzt per Klick auf den Header ein- und ausklappbar
- Chevron-Pfeil zeigt den Zustand an (offen/geschlossen)
- Funktioniert bei offenen und gekauften Artikeln
- Zustand bleibt während der Session erhalten

## Test plan

- [ ] Einkaufsliste öffnen mit Artikeln aus verschiedenen Läden
- [ ] Auf einen Laden-Header klicken → Artikel klappen ein, Chevron dreht sich
- [ ] Erneut klicken → Artikel klappen aus
- [ ] Im Gekauft-Bereich: gleiche Funktionalität prüfen
- [ ] Mobile: Touch auf Header funktioniert

🤖 Generated with [Claude Code](https://claude.com/claude-code)