### PR TITLE
fix: Kundenkarte-Popup schliesst sich beim Speichern zuverlässig

### DIFF
--- a/public/kundenkarten.js
+++ b/public/kundenkarten.js
@@ -294,8 +294,10 @@ function stopScan() {
     const container = document.getElementById('scannerContainer');
     if (container) container.style.display = 'none';
     if (html5QrScanner) {
-        html5QrScanner.stop().catch(() => {});
-        html5QrScanner.clear();
+        try {
+            html5QrScanner.stop().catch(() => {});
+            html5QrScanner.clear();
+        } catch (e) { /* Scanner cleanup fehlgeschlagen – ignorieren */ }
         html5QrScanner = null;
     }
 }
@@ -320,19 +322,24 @@ async function saveKarte() {
 
     const method = id ? 'PUT' : 'POST';
     const url = id ? `/api/kundenkarten/${id}` : '/api/kundenkarten';
-    const res = await fetch(url, {
-        method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, kartennummer, notiz, barcodeFormat })
-    });
+    try {
+        const res = await fetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, kartennummer, notiz, barcodeFormat })
+        });
 
-    if (res.ok) {
-        toast(id ? 'Karte aktualisiert' : 'Karte hinzugefügt');
-        closeKarteModal();
-        loadKarten();
-    } else {
-        const data = await res.json().catch(() => null);
-        errEl.textContent = data?.error || 'Fehler beim Speichern.';
+        if (res.ok) {
+            closeKarteModal();
+            toast(id ? 'Karte aktualisiert' : 'Karte hinzugefügt');
+            loadKarten();
+        } else {
+            const data = await res.json().catch(() => null);
+            errEl.textContent = data?.error || 'Fehler beim Speichern.';
+            errEl.style.display = '';
+        }
+    } catch (e) {
+        errEl.textContent = 'Netzwerkfehler beim Speichern.';
         errEl.style.display = '';
     }
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'haushalt-plus-v2';
+const CACHE_NAME = 'haushalt-plus-v3';
 const ASSETS = [
     './',
     './index.html',


### PR DESCRIPTION
## Summary
- **stopScan() try-catch**: `html5QrScanner.clear()` in try-catch gewrappt – wenn der Scanner-Cleanup fehlschlägt, wird `closeKarteModal()` nicht mehr abgebrochen und das Modal schliesst sich zuverlässig
- **saveKarte() try-catch + Reihenfolge**: Fetch in try-catch gewrappt für Netzwerkfehler-Feedback; `closeKarteModal()` vor `toast()` verschoben damit das Popup sofort schliesst
- **SW-Cache v3**: Service Worker Cache Version gebumpt damit alle Nutzer den neuen Code erhalten

## Test plan
- [ ] Kundenkarte bearbeiten → Speichern → Popup muss sich schliessen
- [ ] Neue Kundenkarte hinzufügen → Speichern → Popup muss sich schliessen
- [ ] Kundenkarte mit Barcode-Scanner scannen → Speichern → Popup muss sich schliessen
- [ ] Server stoppen → Speichern → Fehlermeldung «Netzwerkfehler beim Speichern» wird angezeigt
- [ ] Hard-Reload → Service Worker aktualisiert Cache auf v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)